### PR TITLE
154 cleanup and small improvements collection task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
+ "hf",
  "libp2p",
  "log",
  "moksha-core",
@@ -2205,6 +2206,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hf"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e98b3bb949dd6ea700d2b2d13bda68b63b53c051df9f5d2c4f40f6fe3bc4f29"
+dependencies = [
+ "windows 0.58.0",
+]
 
 [[package]]
 name = "hkdf"
@@ -7086,6 +7096,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7101,6 +7121,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,5 @@ thiserror = "1.0.64"
 moksha-core = { git = "https://github.com/mtbitcr/moksha" }
 moksha-mint = { git = "https://github.com/mtbitcr/moksha" }
 moksha-wallet = { git = "https://github.com/mtbitcr/moksha" }
+hf = { version = "0.3.6", default-features = false }
 

--- a/src/bill/mod.rs
+++ b/src/bill/mod.rs
@@ -475,7 +475,7 @@ pub fn get_path_for_bill_keys(key_name: &str) -> PathBuf {
     path
 }
 
-pub fn get_bills() -> Vec<BitcreditBill> {
+pub async fn get_bills() -> Vec<BitcreditBill> {
     let mut bills = Vec::new();
     let paths = fs::read_dir(BILLS_FOLDER_PATH).unwrap();
     for path in paths {
@@ -487,7 +487,8 @@ pub fn get_bills() -> Vec<BitcreditBill> {
                     .expect("File name error")
                     .to_str()
                     .expect("File name error"),
-            );
+            )
+            .await;
             bills.push(bill);
         }
     }
@@ -514,13 +515,13 @@ pub async fn get_bills_for_list() -> Vec<BitcreditBillToReturn> {
     bills
 }
 
-pub fn endorse_bitcredit_bill(
+pub async fn endorse_bitcredit_bill(
     bill_name: &str,
     endorsee: IdentityPublicData,
     timestamp: i64,
 ) -> bool {
     let my_peer_id = read_peer_id_from_file().to_string();
-    let bill = read_bill_from_file(bill_name);
+    let bill = read_bill_from_file(bill_name).await;
 
     let mut blockchain_from_file = Chain::read_chain_from_file(bill_name);
     let last_block = blockchain_from_file.get_latest_block();
@@ -590,7 +591,7 @@ pub async fn mint_bitcredit_bill(
     timestamp: i64,
 ) -> bool {
     let my_peer_id = read_peer_id_from_file().to_string();
-    let bill = read_bill_from_file(bill_name);
+    let bill = read_bill_from_file(bill_name).await;
 
     let mut blockchain_from_file = Chain::read_chain_from_file(bill_name);
     let last_block = blockchain_from_file.get_latest_block();
@@ -657,14 +658,14 @@ pub async fn mint_bitcredit_bill(
     }
 }
 
-pub fn sell_bitcredit_bill(
+pub async fn sell_bitcredit_bill(
     bill_name: &str,
     buyer: IdentityPublicData,
     timestamp: i64,
     amount_numbers: u64,
 ) -> bool {
     let my_peer_id = read_peer_id_from_file().to_string();
-    let bill = read_bill_from_file(bill_name);
+    let bill = read_bill_from_file(bill_name).await;
 
     let mut blockchain_from_file = Chain::read_chain_from_file(bill_name);
     let last_block = blockchain_from_file.get_latest_block();
@@ -726,9 +727,9 @@ pub fn sell_bitcredit_bill(
     }
 }
 
-pub fn request_pay(bill_name: &str, timestamp: i64) -> bool {
+pub async fn request_pay(bill_name: &str, timestamp: i64) -> bool {
     let my_peer_id = read_peer_id_from_file().to_string();
-    let bill = read_bill_from_file(bill_name);
+    let bill = read_bill_from_file(bill_name).await;
 
     let mut blockchain_from_file = Chain::read_chain_from_file(bill_name);
     let last_block = blockchain_from_file.get_latest_block();
@@ -789,9 +790,9 @@ pub fn request_pay(bill_name: &str, timestamp: i64) -> bool {
     }
 }
 
-pub fn request_acceptance(bill_name: &str, timestamp: i64) -> bool {
+pub async fn request_acceptance(bill_name: &str, timestamp: i64) -> bool {
     let my_peer_id = read_peer_id_from_file().to_string();
-    let bill = read_bill_from_file(bill_name);
+    let bill = read_bill_from_file(bill_name).await;
 
     let mut blockchain_from_file = Chain::read_chain_from_file(bill_name);
     let last_block = blockchain_from_file.get_latest_block();
@@ -852,9 +853,9 @@ pub fn request_acceptance(bill_name: &str, timestamp: i64) -> bool {
     }
 }
 
-pub fn accept_bill(bill_name: &str, timestamp: i64) -> bool {
+pub async fn accept_bill(bill_name: &str, timestamp: i64) -> bool {
     let my_peer_id = read_peer_id_from_file().to_string();
-    let bill = read_bill_from_file(bill_name);
+    let bill = read_bill_from_file(bill_name).await;
 
     let mut blockchain_from_file = Chain::read_chain_from_file(bill_name);
     let last_block = blockchain_from_file.get_latest_block();
@@ -908,7 +909,7 @@ pub fn accept_bill(bill_name: &str, timestamp: i64) -> bool {
 }
 
 async fn read_bill_with_chain_from_file(id: &str) -> BitcreditBillToReturn {
-    let bill: BitcreditBill = read_bill_from_file(id);
+    let bill: BitcreditBill = read_bill_from_file(id).await;
     let chain = Chain::read_chain_from_file(&bill.name);
     let drawer = chain.get_drawer();
     let chain_to_return = ChainToReturn::new(chain.clone());
@@ -962,9 +963,9 @@ async fn read_bill_with_chain_from_file(id: &str) -> BitcreditBillToReturn {
     }
 }
 
-pub fn read_bill_from_file(bill_name: &str) -> BitcreditBill {
+pub async fn read_bill_from_file(bill_name: &str) -> BitcreditBill {
     let chain = Chain::read_chain_from_file(bill_name);
-    chain.get_last_version_bill()
+    chain.get_last_version_bill().await
 }
 
 pub fn bill_from_byte_array(bill: &[u8]) -> BitcreditBill {

--- a/src/bill/mod.rs
+++ b/src/bill/mod.rs
@@ -17,7 +17,7 @@ use openssl::rsa::Rsa;
 use openssl::sha::sha256;
 use rocket::serde::{Deserialize, Serialize};
 use rocket::FromForm;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::{fs, thread};
 
 pub mod contacts;
@@ -481,18 +481,13 @@ pub fn get_bills() -> Vec<BitcreditBill> {
     for _path in paths {
         let dir = _path.unwrap();
         if util::is_not_hidden(&dir) {
-            let file_name = dir
-                .file_name()
-                .to_str()
-                .expect("File name error")
-                .to_string();
-            //TODO change
-            let path_without_extension = Path::file_stem(Path::new(&file_name))
-                .expect("File name error")
-                .to_str()
-                .expect("File name error")
-                .to_string();
-            let bill = read_bill_from_file(&path_without_extension);
+            let bill = read_bill_from_file(
+                dir.path()
+                    .file_stem()
+                    .expect("File name error")
+                    .to_str()
+                    .expect("File name error"),
+            );
             bills.push(bill);
         }
     }
@@ -505,21 +500,17 @@ pub fn get_bills_for_list() -> Vec<BitcreditBillToReturn> {
     for _path in paths {
         let dir = _path.unwrap();
         if util::is_not_hidden(&dir) {
-            let file_name = dir
-                .file_name()
-                .to_str()
-                .expect("File name error")
-                .to_string();
-            //TODO change
-            let path_without_extension = Path::file_stem(Path::new(&file_name))
-                .expect("File name error")
-                .to_str()
-                .expect("File name error")
-                .to_string();
-            let bill =
-                thread::spawn(move || read_bill_with_chain_from_file(&path_without_extension))
-                    .join()
-                    .expect("Thread panicked");
+            let bill = thread::spawn(move || {
+                read_bill_with_chain_from_file(
+                    dir.path()
+                        .file_stem()
+                        .expect("File name error")
+                        .to_str()
+                        .expect("File name error"),
+                )
+            })
+            .join()
+            .expect("Thread panicked");
             bills.push(bill);
         }
     }

--- a/src/bill/mod.rs
+++ b/src/bill/mod.rs
@@ -17,7 +17,7 @@ use openssl::rsa::Rsa;
 use openssl::sha::sha256;
 use rocket::serde::{Deserialize, Serialize};
 use rocket::FromForm;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{fs, thread};
 
 pub mod contacts;
@@ -449,7 +449,7 @@ fn write_bill_keys_to_file(bill_name: String, private_key: String, public_key: S
         public_key_pem: public_key,
     };
 
-    let output_path = BILLS_KEYS_FOLDER_PATH.to_string() + "/" + bill_name.as_str() + ".json";
+    let output_path = get_path_for_bill_keys(&bill_name);
     fs::write(
         output_path.clone(),
         serde_json::to_string_pretty(&keys).unwrap(),
@@ -461,6 +461,18 @@ fn create_bill_name(public_key: &PublicKey) -> String {
     let bill_name_hash: Vec<u8> = sha256(&public_key.to_bytes()).to_vec();
 
     hex::encode(bill_name_hash)
+}
+
+pub fn get_path_for_bill(bill_name: &str) -> PathBuf {
+    let mut path = PathBuf::from(BILLS_FOLDER_PATH).join(bill_name);
+    path.set_extension("json");
+    path
+}
+
+pub fn get_path_for_bill_keys(key_name: &str) -> PathBuf {
+    let mut path = PathBuf::from(BILLS_KEYS_FOLDER_PATH).join(key_name);
+    path.set_extension("json");
+    path
 }
 
 pub fn get_bills() -> Vec<BitcreditBill> {
@@ -973,7 +985,7 @@ pub fn bill_from_byte_array(bill: &[u8]) -> BitcreditBill {
 }
 
 pub fn read_keys_from_bill_file(bill_name: &str) -> BillKeys {
-    let input_path = BILLS_KEYS_FOLDER_PATH.to_string() + "/" + bill_name + ".json";
+    let input_path = get_path_for_bill_keys(bill_name);
     let blockchain_from_file = fs::read(input_path.clone()).expect("file not found");
     serde_json::from_slice(blockchain_from_file.as_slice()).unwrap()
 }

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -8,10 +8,11 @@ use std::thread;
 use super::block::Block;
 use super::calculate_hash;
 use super::OperationCode;
+use crate::bill::get_path_for_bill;
 use crate::blockchain::OperationCode::{
     Accept, Endorse, Issue, Mint, RequestToAccept, RequestToPay, Sell,
 };
-use crate::constants::{BILLS_FOLDER_PATH, USEDNET};
+use crate::constants::USEDNET;
 use crate::external;
 use crate::service::contact_service::IdentityPublicData;
 use crate::{
@@ -43,18 +44,16 @@ impl Chain {
     }
 
     pub fn read_chain_from_file(bill_name: &str) -> Self {
-        let input_path = BILLS_FOLDER_PATH.to_string() + "/" + bill_name + ".json";
-        let blockchain_from_file = std::fs::read(input_path.clone()).expect("file not found");
+        let input_path = get_path_for_bill(bill_name);
+
+        let blockchain_from_file = std::fs::read(input_path).expect("file not found");
         serde_json::from_slice(blockchain_from_file.as_slice()).unwrap()
     }
 
     pub fn write_chain_to_file(&self, bill_name: &str) {
-        let output_path = BILLS_FOLDER_PATH.to_string() + "/" + bill_name + ".json";
-        std::fs::write(
-            output_path.clone(),
-            serde_json::to_string_pretty(&self).unwrap(),
-        )
-        .unwrap();
+        let output_path = get_path_for_bill(bill_name);
+
+        std::fs::write(output_path, serde_json::to_string_pretty(&self).unwrap()).unwrap();
     }
 
     pub fn is_chain_valid(&self) -> bool {
@@ -104,13 +103,12 @@ impl Chain {
     }
 
     pub fn exist_block_with_operation_code(&self, operation_code: OperationCode) -> bool {
-        let mut exist_block_with_operation_code = false;
         for block in &self.blocks {
             if block.operation_code == operation_code {
-                exist_block_with_operation_code = true;
+                return true;
             }
         }
-        exist_block_with_operation_code
+        false
     }
 
     pub fn get_last_version_bill(&self) -> BitcreditBill {

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -1,10 +1,3 @@
-use log::error;
-use openssl::pkey::Private;
-use openssl::rsa::Rsa;
-use serde::{Deserialize, Serialize};
-use std::str::FromStr;
-use std::thread;
-
 use super::block::Block;
 use super::calculate_hash;
 use super::OperationCode;
@@ -21,8 +14,13 @@ use crate::{
 };
 use borsh_derive::BorshDeserialize;
 use borsh_derive::BorshSerialize;
+use log::error;
 use log::warn;
+use openssl::pkey::Private;
+use openssl::rsa::Rsa;
 use rocket::FromForm;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Chain {
@@ -111,7 +109,7 @@ impl Chain {
         false
     }
 
-    pub fn get_last_version_bill(&self) -> BitcreditBill {
+    pub async fn get_last_version_bill(&self) -> BitcreditBill {
         let first_block = self.get_first_block();
 
         let bill_keys = read_keys_from_bill_file(&first_block.bill_name);
@@ -142,7 +140,7 @@ impl Chain {
             let last_version_block_sell = self.get_last_version_block_with_operation_code(Sell);
             let last_block = self.get_latest_block();
 
-            let paid = Self::check_if_last_sell_block_is_paid(self);
+            let paid = Self::check_if_last_sell_block_is_paid(self).await;
 
             if (last_version_block_endorse.id < last_version_block_sell.id)
                 && (last_version_block_mint.id < last_version_block_sell.id)
@@ -259,7 +257,7 @@ impl Chain {
         }
     }
 
-    pub fn waiting_for_payment(
+    pub async fn waiting_for_payment(
         &self,
     ) -> (bool, IdentityPublicData, IdentityPublicData, String, u64) {
         let last_block = self.get_latest_block();
@@ -332,9 +330,8 @@ impl Chain {
 
             let address_to_pay_for_async = address_to_pay.clone();
 
-            let paid = thread::spawn(move || Self::check_if_paid(address_to_pay_for_async, amount))
-                .join()
-                .expect("Thread panicked");
+            let (paid, _amount) =
+                external::bitcoin::check_if_paid(address_to_pay_for_async, amount).await;
 
             (
                 !paid,
@@ -367,7 +364,7 @@ impl Chain {
         diference > period
     }
 
-    fn check_if_last_sell_block_is_paid(&self) -> bool {
+    async fn check_if_last_sell_block_is_paid(&self) -> bool {
         if self.exist_block_with_operation_code(Sell) {
             let last_version_block_sell = self.get_last_version_block_with_operation_code(Sell);
 
@@ -408,9 +405,9 @@ impl Chain {
             let address_to_pay =
                 Self::get_address_to_pay_for_block_sell(last_version_block_sell.clone(), bill);
 
-            thread::spawn(move || Self::check_if_paid(address_to_pay, amount))
-                .join()
-                .expect("Thread panicked")
+            external::bitcoin::check_if_paid(address_to_pay, amount)
+                .await
+                .0
         } else {
             false
         }
@@ -465,24 +462,6 @@ impl Chain {
         let pub_key_bill = bitcoin::PublicKey::new(public_key_bill);
 
         bitcoin::Address::p2pkh(pub_key_bill, USEDNET).to_string()
-    }
-
-    #[tokio::main]
-    async fn check_if_paid(address: String, amount: u64) -> bool {
-        let info_about_address =
-            external::bitcoin::AddressInfo::get_address_info(address.clone()).await;
-        let received_summ = info_about_address.chain_stats.funded_txo_sum;
-        let spent_summ = info_about_address.chain_stats.spent_txo_sum;
-        // let received_summ_mempool = info_about_address.mempool_stats.funded_txo_sum;
-        let spent_summ_mempool = info_about_address.mempool_stats.spent_txo_sum;
-        if amount.eq(&(received_summ + spent_summ
-                // + received_summ_mempool
-                + spent_summ_mempool))
-        {
-            true
-        } else {
-            false
-        }
     }
 
     pub(super) fn get_first_version_bill(&self) -> BitcreditBill {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -9,10 +9,8 @@ use serde::{Deserialize, Serialize};
 use crate::blockchain::OperationCode::{
     Accept, Endorse, Issue, Mint, RequestToAccept, RequestToPay, Sell,
 };
-use crate::constants::BILLS_FOLDER_PATH;
 use crate::service::contact_service::IdentityPublicData;
-use crate::{bill::BitcreditBill, util::rsa::encrypt_bytes};
-
+use crate::{bill::{BitcreditBill, get_path_for_bill}, util::rsa::encrypt_bytes};
 pub use block::Block;
 pub use chain::Chain;
 
@@ -148,12 +146,8 @@ pub fn start_blockchain_for_new_bill(
     );
 
     let chain = Chain::new(first_block);
-    let output_path = BILLS_FOLDER_PATH.to_string() + "/" + bill.name.clone().as_str() + ".json";
-    std::fs::write(
-        output_path.clone(),
-        serde_json::to_string_pretty(&chain).unwrap(),
-    )
-    .unwrap();
+    let output_path = get_path_for_bill(&bill.name);
+    std::fs::write(output_path, serde_json::to_string_pretty(&chain).unwrap()).unwrap();
 }
 
 fn calculate_hash(

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -132,13 +132,13 @@ impl Client {
             for file in fs::read_dir(BILLS_FOLDER_PATH).unwrap() {
                 let dir = file.unwrap();
                 if is_not_hidden(&dir) {
-                    let mut bill_name = dir.file_name().into_string().unwrap();
-
-                    bill_name = Path::file_stem(Path::new(&bill_name))
+                    let bill_name = dir
+                        .path()
+                        .file_stem()
                         .expect("File name error")
                         .to_str()
                         .expect("File name error")
-                        .to_string();
+                        .to_owned();
 
                     if !record_in_dht.contains(&bill_name) {
                         new_record += (",".to_string() + &bill_name.clone()).as_str();
@@ -154,12 +154,13 @@ impl Client {
             for file in fs::read_dir(BILLS_FOLDER_PATH).unwrap() {
                 let dir = file.unwrap();
                 if is_not_hidden(&dir) {
-                    let mut bill_name = dir.file_name().into_string().unwrap();
-                    bill_name = Path::file_stem(Path::new(&bill_name))
+                    let bill_name = dir
+                        .path()
+                        .file_stem()
                         .expect("File name error")
                         .to_str()
                         .expect("File name error")
-                        .to_string();
+                        .to_owned();
 
                     if new_record.is_empty() {
                         new_record = bill_name.clone();
@@ -180,12 +181,13 @@ impl Client {
         for file in fs::read_dir(BILLS_FOLDER_PATH).unwrap() {
             let dir = file.unwrap();
             if is_not_hidden(&dir) {
-                let mut bill_name = dir.file_name().into_string().unwrap();
-                bill_name = Path::file_stem(Path::new(&bill_name))
+                let bill_name = dir
+                    .path()
+                    .file_stem()
                     .expect("File name error")
                     .to_str()
                     .expect("File name error")
-                    .to_string();
+                    .to_owned();
                 self.put(&bill_name).await;
             }
         }

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -332,7 +332,7 @@ impl Client {
     }
 
     pub async fn put_bills_for_parties(&mut self) {
-        let bills = get_bills();
+        let bills = get_bills().await;
 
         for bill in bills {
             let chain = Chain::read_chain_from_file(&bill.name);
@@ -344,7 +344,7 @@ impl Client {
     }
 
     pub async fn subscribe_to_all_bills_topics(&mut self) {
-        let bills = get_bills();
+        let bills = get_bills().await;
 
         for bill in bills {
             self.subscribe_to_topic(bill.name).await;
@@ -352,7 +352,7 @@ impl Client {
     }
 
     pub async fn receive_updates_for_all_bills_topics(&mut self) {
-        let bills = get_bills();
+        let bills = get_bills().await;
 
         for bill in bills {
             let event = GossipsubEvent::new(GossipsubEventId::CommandGetChain, vec![0; 24]);

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -40,7 +40,7 @@ impl Client {
         mut network_events: Receiver<Event>,
     ) {
         loop {
-            futures::select! {
+            tokio::select! {
                 line = stdin.select_next_some() => self.handle_input_line(line.expect("Stdin not to close.")).await,
                 event = network_events.next() => self.handle_event(event.expect("Swarm stream to be infinite.")).await,
             }

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -58,7 +58,7 @@ impl EventLoop {
 
     pub async fn run(mut self) {
         loop {
-            futures::select! {
+            tokio::select! {
                 event = self.swarm.next() => self.handle_event(event.expect("Swarm stream to be infinite.")).await,
                 command = self.command_receiver.next() => if let Some(c) = command { self.handle_command(c).await },
             }

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -81,11 +81,11 @@ async fn new(
     swarm.listen_on(conf.p2p_listen_url().unwrap()).unwrap();
 
     // Wait to listen on all interfaces.
-    let sleep = tokio::time::sleep(std::time::Duration::from_secs(1)).fuse();
+    let sleep = tokio::time::sleep(std::time::Duration::from_secs(1));
     tokio::pin!(sleep);
 
     loop {
-        futures::select! {
+        tokio::select! {
             event = swarm.next() => {
                 match event.unwrap() {
                     SwarmEvent::NewListenAddr { address, .. } => {
@@ -96,7 +96,7 @@ async fn new(
                     event => panic!("{event:?}"),
                 }
             }
-            _ = sleep => {
+            _ = &mut sleep => {
                 // Likely listening on all interfaces now, thus continuing by breaking the loop.
                 break;
             }

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -10,7 +10,6 @@ use behaviour::{ComposedEvent, Event, MyBehaviour};
 use event_loop::EventLoop;
 use futures::channel::mpsc;
 use futures::channel::mpsc::Receiver;
-use futures::executor::block_on;
 use futures::prelude::*;
 use libp2p::core::transport::OrTransport;
 use libp2p::core::upgrade::Version;
@@ -64,18 +63,16 @@ async fn new(
 
     let (relay_transport, client) = relay::client::new(local_peer_id);
 
-    let transport = OrTransport::new(
-        relay_transport,
-        block_on(DnsConfig::system(tcp::tokio::Transport::new(
-            tcp::Config::default().port_reuse(true),
-        )))
-        .unwrap(),
-    )
-    .upgrade(Version::V1Lazy)
-    .authenticate(noise::Config::new(&local_public_key).unwrap())
-    .multiplex(yamux::Config::default())
-    .timeout(std::time::Duration::from_secs(20))
-    .boxed();
+    let dns_cfg = DnsConfig::system(tcp::tokio::Transport::new(
+        tcp::Config::default().port_reuse(true),
+    ))
+    .await;
+    let transport = OrTransport::new(relay_transport, dns_cfg.unwrap())
+        .upgrade(Version::V1Lazy)
+        .authenticate(noise::Config::new(&local_public_key).unwrap())
+        .multiplex(yamux::Config::default())
+        .timeout(std::time::Duration::from_secs(20))
+        .boxed();
 
     let behaviour = MyBehaviour::new(local_peer_id, local_public_key.clone(), client);
 
@@ -84,29 +81,27 @@ async fn new(
     swarm.listen_on(conf.p2p_listen_url().unwrap()).unwrap();
 
     // Wait to listen on all interfaces.
-    block_on(async {
-        let sleep = tokio::time::sleep(std::time::Duration::from_secs(1)).fuse();
-        tokio::pin!(sleep);
+    let sleep = tokio::time::sleep(std::time::Duration::from_secs(1)).fuse();
+    tokio::pin!(sleep);
 
-        loop {
-            futures::select! {
-                event = swarm.next() => {
-                    match event.unwrap() {
-                        SwarmEvent::NewListenAddr { address, .. } => {
-                            info!("Listening on {:?}", address);
-                        }
-                        SwarmEvent::Behaviour { .. } => {
-                        }
-                        event => panic!("{event:?}"),
+    loop {
+        futures::select! {
+            event = swarm.next() => {
+                match event.unwrap() {
+                    SwarmEvent::NewListenAddr { address, .. } => {
+                        info!("Listening on {:?}", address);
                     }
-                }
-                _ = sleep => {
-                    // Likely listening on all interfaces now, thus continuing by breaking the loop.
-                    break;
+                    SwarmEvent::Behaviour { .. } => {
+                    }
+                    event => panic!("{event:?}"),
                 }
             }
+            _ = sleep => {
+                // Likely listening on all interfaces now, thus continuing by breaking the loop.
+                break;
+            }
         }
-    });
+    }
 
     let relay_peer_id: PeerId = RELAY_BOOTSTRAP_NODE_ONE_PEER_ID
         .to_string()
@@ -119,37 +114,33 @@ async fn new(
     info!("Relay address: {:?}", relay_address);
 
     swarm.dial(relay_address.clone()).unwrap();
-    block_on(async {
-        let mut learned_observed_addr = false;
-        let mut told_relay_observed_addr = false;
+    let mut learned_observed_addr = false;
+    let mut told_relay_observed_addr = false;
 
-        loop {
-            match swarm.next().await.unwrap() {
-                SwarmEvent::NewListenAddr { .. } => {}
-                SwarmEvent::Dialing { .. } => {}
-                SwarmEvent::ConnectionEstablished { .. } => {}
-                SwarmEvent::Behaviour(ComposedEvent::Identify(identify::Event::Sent {
-                    ..
-                })) => {
-                    info!("Told relay its public address.");
-                    told_relay_observed_addr = true;
-                }
-                SwarmEvent::Behaviour(ComposedEvent::Identify(identify::Event::Received {
-                    info: identify::Info { observed_addr, .. },
-                    ..
-                })) => {
-                    info!("Relay told us our public address: {:?}", observed_addr);
-                    learned_observed_addr = true;
-                }
-                SwarmEvent::Behaviour { .. } => {}
-                event => panic!("{event:?}"),
+    loop {
+        match swarm.next().await.unwrap() {
+            SwarmEvent::NewListenAddr { .. } => {}
+            SwarmEvent::Dialing { .. } => {}
+            SwarmEvent::ConnectionEstablished { .. } => {}
+            SwarmEvent::Behaviour(ComposedEvent::Identify(identify::Event::Sent { .. })) => {
+                info!("Told relay its public address.");
+                told_relay_observed_addr = true;
             }
-
-            if learned_observed_addr && told_relay_observed_addr {
-                break;
+            SwarmEvent::Behaviour(ComposedEvent::Identify(identify::Event::Received {
+                info: identify::Info { observed_addr, .. },
+                ..
+            })) => {
+                info!("Relay told us our public address: {:?}", observed_addr);
+                learned_observed_addr = true;
             }
+            SwarmEvent::Behaviour { .. } => {}
+            event => panic!("{event:?}"),
         }
-    });
+
+        if learned_observed_addr && told_relay_observed_addr {
+            break;
+        }
+    }
 
     swarm.behaviour_mut().bootstrap_kademlia();
 
@@ -157,42 +148,40 @@ async fn new(
         .listen_on(relay_address.clone().with(Protocol::P2pCircuit))
         .unwrap();
 
-    block_on(async {
-        loop {
-            match swarm.next().await.unwrap() {
-                SwarmEvent::NewListenAddr { address, .. } => {
-                    info!("Listening on {:?}", address);
-                    break;
-                }
-                SwarmEvent::Behaviour(ComposedEvent::Relay(
-                    relay::client::Event::ReservationReqAccepted { .. },
-                )) => {
-                    info!("Relay accepted our reservation request.");
-                }
-                SwarmEvent::Behaviour(ComposedEvent::Relay(event)) => {
-                    info!("Relay event: {:?}", event)
-                }
-                SwarmEvent::Behaviour(ComposedEvent::Dcutr(event)) => {
-                    info!("Dcutr event: {:?}", event)
-                }
-                SwarmEvent::Behaviour(ComposedEvent::Identify(event)) => {
-                    info!("Identify event: {:?}", event)
-                }
-                SwarmEvent::ConnectionEstablished {
-                    peer_id, endpoint, ..
-                } => {
-                    info!("Established connection to {:?} via {:?}", peer_id, endpoint);
-                }
-                SwarmEvent::OutgoingConnectionError { peer_id, error } => {
-                    error!("Outgoing connection error to {:?}: {:?}", peer_id, error);
-                }
-                SwarmEvent::Behaviour(event) => {
-                    info!("Behaviour event: {event:?}")
-                }
-                _ => {}
+    loop {
+        match swarm.next().await.unwrap() {
+            SwarmEvent::NewListenAddr { address, .. } => {
+                info!("Listening on {:?}", address);
+                break;
             }
+            SwarmEvent::Behaviour(ComposedEvent::Relay(
+                relay::client::Event::ReservationReqAccepted { .. },
+            )) => {
+                info!("Relay accepted our reservation request.");
+            }
+            SwarmEvent::Behaviour(ComposedEvent::Relay(event)) => {
+                info!("Relay event: {:?}", event)
+            }
+            SwarmEvent::Behaviour(ComposedEvent::Dcutr(event)) => {
+                info!("Dcutr event: {:?}", event)
+            }
+            SwarmEvent::Behaviour(ComposedEvent::Identify(event)) => {
+                info!("Identify event: {:?}", event)
+            }
+            SwarmEvent::ConnectionEstablished {
+                peer_id, endpoint, ..
+            } => {
+                info!("Established connection to {:?} via {:?}", peer_id, endpoint);
+            }
+            SwarmEvent::OutgoingConnectionError { peer_id, error } => {
+                error!("Outgoing connection error to {:?}: {:?}", peer_id, error);
+            }
+            SwarmEvent::Behaviour(event) => {
+                info!("Behaviour event: {event:?}")
+            }
+            _ => {}
         }
-    });
+    }
 
     let (command_sender, command_receiver) = mpsc::channel(0);
     let (event_sender, event_receiver) = mpsc::channel(0);

--- a/src/external/mint.rs
+++ b/src/external/mint.rs
@@ -18,6 +18,8 @@ use crate::bill::{
 };
 use crate::web::RequestToMintBitcreditBillForm;
 
+// Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
+// this logic will be replaced soon
 #[tokio::main]
 pub async fn accept_mint_bitcredit(
     amount: u64,
@@ -43,6 +45,8 @@ pub async fn accept_mint_bitcredit(
     req.await.unwrap()
 }
 
+// Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
+// this logic will be replaced soon
 #[tokio::main]
 pub async fn check_bitcredit_quote(bill_id: &str) {
     let dir = PathBuf::from("./data/wallet".to_string());
@@ -74,6 +78,8 @@ pub async fn check_bitcredit_quote(bill_id: &str) {
     // quote
 }
 
+// Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
+// this logic will be replaced soon
 #[tokio::main]
 pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
     let dir = PathBuf::from("./data/wallet".to_string());
@@ -126,6 +132,8 @@ pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
     token
 }
 
+// Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
+// this logic will be replaced soon
 #[tokio::main]
 pub async fn request_to_mint_bitcredit(
     form: RequestToMintBitcreditBillForm,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -157,7 +157,7 @@ mod test {
     //         public_data_payee,
     //     );
     //
-    //     let bill2 = read_bill_from_file(&bill.name);
+    //     let bill2 = read_bill_from_file(&bill.name).await;
     //
     //     assert_eq!(bill.bill_jurisdiction, bill2.bill_jurisdiction);
     // }
@@ -181,7 +181,7 @@ mod test {
     //
     //     let bill = read_bill_from_file(
     //         &"5f58c116fa86af48dc4442e7daa4cf062564415fad31a889b3ed7e02f76bcf8b".to_string(),
-    //     );
+    //     ).await;
     //
     //     assert_eq!(bill.bill_jurisdiction, "bill.bill_jurisdiction".to_string());
     // }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,9 +8,8 @@ pub unsafe fn structure_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
 }
 
 pub fn is_not_hidden(entry: &DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .map(|s| !s.starts_with("."))
-        .unwrap_or(false)
+    match hf::is_hidden(entry.path()) {
+        Ok(res) => !res,
+        Err(_) => false,
+    }
 }

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -588,6 +588,8 @@ pub async fn request_to_mint_bill(
             .await;
     }
 
+    // Usage of thread::spawn is necessary here, because we spawn a new tokio runtime in the
+    // thread, but this logic will be replaced soon
     thread::spawn(move || request_to_mint_bitcredit(request_to_mint_bill_form.clone()))
         .join()
         .expect("Thread panicked");
@@ -602,6 +604,8 @@ pub async fn accept_mint_bill(accept_mint_bill_form: Form<AcceptMintBitcreditBil
     let holder_node_id = bill.payee.peer_id.clone();
 
     //TODO: calculate percent
+    // Usage of thread::spawn is necessary here, because we spawn a new tokio runtime in the
+    // thread, but this logic will be replaced soon
     thread::spawn(move || {
         accept_mint_bitcredit(
             bill_amount,

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -38,7 +38,7 @@ pub async fn holder(id: String) -> Json<bool> {
 
 #[get("/return")]
 pub async fn return_bills_list() -> Json<Vec<BitcreditBillToReturn>> {
-    let bills: Vec<BitcreditBillToReturn> = get_bills_for_list();
+    let bills: Vec<BitcreditBillToReturn> = get_bills_for_list().await;
     Json(bills)
 }
 

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -4,8 +4,9 @@ use super::super::data::{
     RequestToMintBitcreditBillForm, RequestToPayBitcreditBillForm, SellBitcreditBillForm,
 };
 use crate::bill::contacts::get_current_payee_private_key;
+use crate::bill::get_path_for_bill;
 use crate::blockchain::{Chain, ChainToReturn, GossipsubEvent, GossipsubEventId, OperationCode};
-use crate::constants::{BILLS_FOLDER_PATH, IDENTITY_FILE_PATH};
+use crate::constants::IDENTITY_FILE_PATH;
 use crate::external;
 use crate::external::mint::{accept_mint_bitcredit, request_to_mint_bitcredit};
 use crate::service::contact_service::IdentityPublicData;
@@ -58,7 +59,7 @@ pub async fn find_bill_in_dht(state: &State<ServiceContext>, bill_id: String) {
     let mut client = state.dht_client();
     let bill_bytes = client.get_bill(bill_id.to_string().clone()).await;
     if !bill_bytes.is_empty() {
-        let path = BILLS_FOLDER_PATH.to_string() + "/" + &bill_id + ".json";
+        let path = get_path_for_bill(&bill_id);
         fs::write(path, bill_bytes.clone()).expect("Can't write file.");
     }
 }

--- a/src/web/handlers/quotes.rs
+++ b/src/web/handlers/quotes.rs
@@ -35,7 +35,7 @@ pub async fn accept_quote(
 
     if !public_data_endorsee.name.is_empty() {
         let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
-        endorse_bitcredit_bill(&quote.bill_id, public_data_endorsee.clone(), timestamp);
+        endorse_bitcredit_bill(&quote.bill_id, public_data_endorsee.clone(), timestamp).await;
     }
 
     let copy_id = id.clone();

--- a/src/web/handlers/quotes.rs
+++ b/src/web/handlers/quotes.rs
@@ -11,6 +11,8 @@ pub async fn return_quote(id: String) -> Json<BitcreditEbillQuote> {
     let mut quote = get_quote_from_map(&id);
     let copy_id = id.clone();
     if !quote.bill_id.is_empty() && quote.quote_id.is_empty() {
+        // Usage of thread::spawn is necessary here, because we spawn a new tokio runtime in the
+        // thread, but this logic will be replaced soon
         thread::spawn(move || check_bitcredit_quote(&copy_id))
             .join()
             .expect("Thread panicked");
@@ -38,6 +40,8 @@ pub async fn accept_quote(
 
     let copy_id = id.clone();
     if !quote.bill_id.is_empty() && !quote.quote_id.is_empty() {
+        // Usage of thread::spawn is necessary here, because we spawn a new tokio runtime in the
+        // thread, but this logic will be replaced soon
         thread::spawn(move || client_accept_bitcredit_quote(&copy_id))
             .join()
             .expect("Thread panicked");


### PR DESCRIPTION
This fixes the list of small improvements in https://github.com/BitcreditProtocol/E-Bill/issues/154 (some where already fixed within other tasks).

The most important parts are around async handling (removed the `block_on` calls), as well as path-building.

Also, usages of thread::spawn and tokio::main (beyond main.rs) were documented to be replaced soon with the new mint.