### PR TITLE
81 elegant termination and clearing of resources exit from programme closing of ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-stream",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ libp2p = { version = "0.51.3", features = [
   "dcutr",
 ] }
 tokio = { version = "1.40.0", features = ["rt", "rt-multi-thread", "macros", "io-util", "time", "io-std"] }
-tokio-stream = { version = "0.1.16", features = ["io-util"] }
 async-trait = "0.1.83"
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_dyn_templates = { version = "0.2.0", features = ["handlebars"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::net::Ipv4Addr;
 /// Configuration for the bitcredit application
 /// Allows to set the ports and addresses for the http and p2p connections
 /// either via command line or environment variables
-#[derive(Debug, Parser, Clone)]
+#[derive(Parser, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Config {
     #[arg(default_value_t = 1908, long, env = "P2P_PORT")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::net::Ipv4Addr;
 /// Configuration for the bitcredit application
 /// Allows to set the ports and addresses for the http and p2p connections
 /// either via command line or environment variables
-#[derive(Parser, Clone)]
+#[derive(Debug, Parser, Clone)]
 #[command(version, about, long_about = None)]
 pub struct Config {
     #[arg(default_value_t = 1908, long, env = "P2P_PORT")]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,7 @@ use std::net::Ipv4Addr;
 pub const BILLS_PREFIX: &str = "BILLS";
 pub const BILL_PREFIX: &str = "BILL_";
 pub const KEY_PREFIX: &str = "KEY_";
-pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 3000;
+pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1000;
 
 // Paths
 pub const IDENTITY_FOLDER_PATH: &str = "identity";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,7 @@ use std::net::Ipv4Addr;
 pub const BILLS_PREFIX: &str = "BILLS";
 pub const BILL_PREFIX: &str = "BILL_";
 pub const KEY_PREFIX: &str = "KEY_";
+pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 3000;
 
 // Paths
 pub const IDENTITY_FOLDER_PATH: &str = "identity";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,7 +5,7 @@ use std::net::Ipv4Addr;
 pub const BILLS_PREFIX: &str = "BILLS";
 pub const BILL_PREFIX: &str = "BILL_";
 pub const KEY_PREFIX: &str = "KEY_";
-pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1000;
+pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1500;
 
 // Paths
 pub const IDENTITY_FOLDER_PATH: &str = "identity";

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -41,14 +41,13 @@ pub async fn dht_main(conf: &Config) -> Result<Dht, Box<dyn Error + Send + Sync>
         .await
         .expect("Can not to create network module in dht.");
 
-    let (shutdown_sender, shutdown_receiver) = broadcast::channel::<bool>(64);
+    let (shutdown_sender, shutdown_receiver) = broadcast::channel::<bool>(100);
 
     spawn(network_event_loop.run(shutdown_receiver));
 
     let network_client_to_return = network_client.clone();
 
-    let shutdown_dht_client_receiver = shutdown_sender.subscribe();
-    spawn(network_client.run(network_events, shutdown_dht_client_receiver));
+    spawn(network_client.run(network_events, shutdown_sender.subscribe()));
 
     Ok(Dht {
         client: network_client_to_return,

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<()> {
     }
 
     info!("Waiting for application to exit...");
+    // If the web server exits fast, we wait for a grace period so libp2p can finish as well
     tokio::time::sleep(std::time::Duration::from_millis(SHUTDOWN_GRACE_PERIOD_MS)).await;
 
     Ok(())

--- a/src/web/handlers/mod.rs
+++ b/src/web/handlers/mod.rs
@@ -1,6 +1,7 @@
 use crate::blockchain::OperationCode;
-use rocket::get;
+use crate::service::ServiceContext;
 use rocket::serde::json::Json;
+use rocket::{get, Shutdown, State};
 
 pub mod bill;
 pub mod contacts;
@@ -8,8 +9,10 @@ pub mod identity;
 pub mod quotes;
 
 #[get("/")]
-pub async fn exit() {
-    std::process::exit(0x0100);
+pub async fn exit(shutdown: Shutdown, state: &State<ServiceContext>) {
+    log::info!("Exit called - shutting down...");
+    shutdown.notify();
+    state.shutdown();
 }
 
 #[get("/return")]


### PR DESCRIPTION
This implements #81 with some basic graceful-shutdown logic if `/exit` is called, or `ctrl-c` is pressed.

We could theoretically do more regarding libp2p (on shutdown event go through all connected peers and close connections etc.) and notify an orchestrator, which waits for all parts to be finished (or a grace period to run out), but I'm not sure it'll be needed - that's something we'd have to test with more traffic.

The current implementation sends an event to the web server (which does it's own graceful shutdown), the dht client and the dht event loop and in every case, they quit, which means from the time the event happens, no further requests, or events will be processed, but currently processing events should finish. The event loop (with the swarm) is dropped, which cleans up existing libp2p connections.

One thing I had to change was stdin handling, since the tokio's async stdin blocks forever on process exit and is not supposed to be used for interactive use-cases such as this (https://docs.rs/tokio/latest/tokio/io/struct.Stdin.html), but logic-wise it's the same (underneath, tokio also just spawns a thread and blocks there)