### PR TITLE
157: replace unsafe key and peer id serialization with builtin protobuf logic

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,10 +3,6 @@ use std::fs::DirEntry;
 pub mod numbers_to_words;
 pub mod rsa;
 
-pub unsafe fn structure_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
-    std::slice::from_raw_parts((p as *const T) as *const u8, size_of::<T>())
-}
-
 pub fn is_not_hidden(entry: &DirEntry) -> bool {
     match hf::is_hidden(entry.path()) {
         Ok(res) => !res,


### PR DESCRIPTION
This fixes #157 and removes all `unsafe` uses in the code base.

The reason was that the serialization as it was before was unsound, since the memory layout of Keypair and PeerId can't be relied upon to be stable (not repr(C)/repr(transparent)).

Instead, the built-in variant is now used, using protobuf or the builtin `to_bytes` in the case of the PeerId.

This also means, that once this is merged, all previous identities stop working, since the serialization format is changed, which is why we decided to do this earlier rather than later.

I also changed the test to demonstrate that this approach works.