### PR TITLE
115: upload files in bill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /contacts/*
 /quotes/*
 /test/*
+/files/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ dependencies = [
  "futures",
  "hex",
  "hf",
+ "infer",
  "lettre",
  "libp2p",
  "log",
@@ -893,6 +894,7 @@ dependencies = [
  "thiserror 2.0.0",
  "tokio",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2843,6 +2845,12 @@ dependencies = [
  "hashbrown 0.14.5",
  "serde",
 ]
+
+[[package]]
+name = "infer"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865e8a58ae8e24d2c4412c31344afa1d302a3740ad67528c10f50d6876cdcf55"
 
 [[package]]
 name = "inlinable_string"
@@ -7496,9 +7504,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.40.0", features = [
   "io-util",
   "time",
   "io-std",
+  "fs",
 ] }
 async-trait = "0.1.83"
 rocket = { version = "0.5.1", features = ["json"] }
@@ -58,6 +59,8 @@ lettre = { version = "0.11.10", features = [
   "file-transport",
 ] }
 nostr-sdk = "0.36.0"
+uuid = { version = "1.11.0", features = ["v4"] }
+infer = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 mockall = "0.13.0"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-too-many-arguments-threshold=11
+too-many-arguments-threshold=12

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -255,6 +255,7 @@ impl Chain {
             public_key: bill_first_version.public_key,
             private_key: bill_first_version.private_key,
             language: bill_first_version.language,
+            files: bill_first_version.files,
         }
     }
 
@@ -360,7 +361,10 @@ impl Chain {
 
     async fn payment_deadline_has_passed(timestamp: i64, day: i32) -> bool {
         let period: i64 = (86400 * day) as i64;
-        let current_timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+        let current_timestamp = external::time::TimeApi::get_atomic_time()
+            .await
+            .unwrap()
+            .timestamp;
         let diference = current_timestamp - timestamp;
         diference > period
     }
@@ -534,14 +538,14 @@ impl Chain {
         drawer
     }
 
-    pub fn bill_contain_node(&self, request_node_id: String) -> bool {
+    pub fn bill_contains_node(&self, request_node_id: &str) -> bool {
         for block in &self.blocks {
             match block.operation_code {
                 Issue => {
                     let bill = self.get_first_version_bill();
-                    if bill.drawer.peer_id.eq(&request_node_id)
-                        || bill.drawee.peer_id.eq(&request_node_id)
-                        || bill.payee.peer_id.eq(&request_node_id)
+                    if bill.drawer.peer_id.eq(request_node_id)
+                        || bill.drawee.peer_id.eq(request_node_id)
+                        || bill.payee.peer_id.eq(request_node_id)
                     {
                         return true;
                     }
@@ -586,8 +590,8 @@ impl Chain {
                     let endorser_bill: IdentityPublicData =
                         serde_json::from_slice(&endorser_bill_u8).unwrap();
 
-                    if endorsee_bill.peer_id.eq(&request_node_id)
-                        || endorser_bill.peer_id.eq(&request_node_id)
+                    if endorsee_bill.peer_id.eq(request_node_id)
+                        || endorser_bill.peer_id.eq(request_node_id)
                     {
                         return true;
                     }
@@ -632,8 +636,8 @@ impl Chain {
                     let mint_bill: IdentityPublicData =
                         serde_json::from_slice(&mint_bill_u8).unwrap();
 
-                    if minter_bill.peer_id.eq(&request_node_id)
-                        || mint_bill.peer_id.eq(&request_node_id)
+                    if minter_bill.peer_id.eq(request_node_id)
+                        || mint_bill.peer_id.eq(request_node_id)
                     {
                         return true;
                     }
@@ -658,7 +662,7 @@ impl Chain {
                     let requester_to_accept_bill: IdentityPublicData =
                         serde_json::from_slice(&requester_to_accept_bill_u8).unwrap();
 
-                    if requester_to_accept_bill.peer_id.eq(&request_node_id) {
+                    if requester_to_accept_bill.peer_id.eq(request_node_id) {
                         return true;
                     }
                 }
@@ -682,7 +686,7 @@ impl Chain {
                     let accepter_bill: IdentityPublicData =
                         serde_json::from_slice(&accepter_bill_u8).unwrap();
 
-                    if accepter_bill.peer_id.eq(&request_node_id) {
+                    if accepter_bill.peer_id.eq(request_node_id) {
                         return true;
                     }
                 }
@@ -706,7 +710,7 @@ impl Chain {
                     let requester_to_pay_bill: IdentityPublicData =
                         serde_json::from_slice(&requester_to_pay_bill_u8).unwrap();
 
-                    if requester_to_pay_bill.peer_id.eq(&request_node_id) {
+                    if requester_to_pay_bill.peer_id.eq(request_node_id) {
                         return true;
                     }
                 }
@@ -758,8 +762,8 @@ impl Chain {
                     let seller_bill: IdentityPublicData =
                         serde_json::from_slice(&seller_bill_u8).unwrap();
 
-                    if buyer_bill.peer_id.eq(&request_node_id)
-                        || seller_bill.peer_id.eq(&request_node_id)
+                    if buyer_bill.peer_id.eq(request_node_id)
+                        || seller_bill.peer_id.eq(request_node_id)
                     {
                         return true;
                     }

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -35,6 +35,7 @@ pub struct BlockForHistory {
 }
 
 impl Chain {
+    #[cfg_attr(test, allow(dead_code))]
     pub fn new(first_block: Block) -> Self {
         let blocks = vec![first_block];
 
@@ -469,7 +470,7 @@ impl Chain {
         bitcoin::Address::p2pkh(pub_key_bill, USEDNET).to_string()
     }
 
-    pub(super) fn get_first_version_bill(&self) -> BitcreditBill {
+    pub fn get_first_version_bill(&self) -> BitcreditBill {
         let first_block_data = &self.get_first_block();
         let bill_keys = read_keys_from_bill_file(&first_block_data.bill_name);
         let key: Rsa<Private> =

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -10,10 +10,7 @@ use crate::blockchain::OperationCode::{
     Accept, Endorse, Issue, Mint, RequestToAccept, RequestToPay, Sell,
 };
 use crate::service::contact_service::IdentityPublicData;
-use crate::{
-    bill::{get_path_for_bill, BitcreditBill},
-    util::rsa::encrypt_bytes,
-};
+use crate::{bill::BitcreditBill, util::rsa::encrypt_bytes};
 pub use block::Block;
 pub use chain::Chain;
 
@@ -121,6 +118,18 @@ pub enum GossipsubEventId {
     CommandGetChain,
 }
 
+#[cfg(test)]
+pub fn start_blockchain_for_new_bill(
+    _bill: &BitcreditBill,
+    _operation_code: OperationCode,
+    _drawer: IdentityPublicData,
+    _public_key: String,
+    _private_key: String,
+    _private_key_pem: String,
+    _timestamp: i64,
+) {
+}
+#[cfg(not(test))]
 pub fn start_blockchain_for_new_bill(
     bill: &BitcreditBill,
     operation_code: OperationCode,
@@ -130,6 +139,8 @@ pub fn start_blockchain_for_new_bill(
     private_key_pem: String,
     timestamp: i64,
 ) {
+    use crate::bill::get_path_for_bill;
+
     let data_for_new_block_in_bytes = serde_json::to_vec(&drawer).unwrap();
     let data_for_new_block = "Signed by ".to_string() + &hex::encode(data_for_new_block_in_bytes);
 
@@ -176,6 +187,7 @@ fn calculate_hash(
     hasher.finish().to_vec()
 }
 
+#[cfg_attr(test, allow(dead_code))]
 fn encrypted_hash_data_from_bill(bill: &BitcreditBill, private_key_pem: String) -> String {
     let bytes = to_vec(bill).unwrap();
     let key: Rsa<Private> = Rsa::private_key_from_pem(private_key_pem.as_bytes()).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub http_port: u16,
     #[arg(default_value_t = String::from("127.0.0.1"), long, env = "HTTP_ADDRESS")]
     pub http_address: String,
-    #[arg(default_value_t = String::from("./"), long, env = "DATA_DIR")]
+    #[arg(default_value_t = String::from("."), long, env = "DATA_DIR")]
     pub data_dir: String,
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,8 +4,14 @@ use std::net::Ipv4Addr;
 // General
 pub const BILLS_PREFIX: &str = "BILLS";
 pub const BILL_PREFIX: &str = "BILL_";
+pub const BILL_ATTACHMENT_PREFIX: &str = "BILLATT_";
 pub const KEY_PREFIX: &str = "KEY_";
 pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1500;
+
+// Validation
+pub const MAX_FILE_SIZE_BYTES: usize = 5_000_000; // ~5 MB
+pub const MAX_FILE_NAME_CHARACTERS: usize = 50;
+pub const VALID_FILE_MIME_TYPES: [&str; 3] = ["image/jpeg", "image/png", "application/pdf"];
 
 // Paths
 pub const IDENTITY_FOLDER_PATH: &str = "identity";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,9 +3,9 @@ use std::net::Ipv4Addr;
 
 // General
 pub const BILLS_PREFIX: &str = "BILLS";
-pub const BILL_PREFIX: &str = "BILL_";
-pub const BILL_ATTACHMENT_PREFIX: &str = "BILLATT_";
-pub const KEY_PREFIX: &str = "KEY_";
+pub const BILL_PREFIX: &str = "BILL";
+pub const BILL_ATTACHMENT_PREFIX: &str = "BILLATT";
+pub const KEY_PREFIX: &str = "KEY";
 pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1500;
 
 // Validation

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -1,9 +1,13 @@
-use super::behaviour::{Command, Event, FileResponse};
+use super::behaviour::{
+    file_request_for_bill_attachment, parse_inbound_file_request, BillAttachmentFileRequest,
+    BillFileRequest, BillKeysFileRequest, Command, Event, FileResponse, ParsedInboundFileRequest,
+};
 use crate::bill::{get_path_for_bill, get_path_for_bill_keys};
 use crate::blockchain::{Chain, GossipsubEvent, GossipsubEventId};
 use crate::constants::{
     BILLS_FOLDER_PATH, BILLS_PREFIX, BILL_PREFIX, IDENTITY_FILE_PATH, KEY_PREFIX,
 };
+use crate::persistence::bill::BillStoreApi;
 use crate::service::contact_service::IdentityPublicData;
 use crate::{
     bill::{
@@ -11,10 +15,11 @@ use crate::{
         identity::{get_whole_identity, read_peer_id_from_file, IdentityWithAll},
     },
     util::{
-        is_not_hidden,
+        file::is_not_hidden_or_directory,
         rsa::{decrypt_bytes_with_private_key, encrypt_bytes_with_public_key},
     },
 };
+use anyhow::{anyhow, Result};
 use futures::channel::mpsc::Receiver;
 use futures::channel::{mpsc, oneshot};
 use futures::prelude::*;
@@ -23,20 +28,21 @@ use libp2p::request_response::ResponseChannel;
 use libp2p::PeerId;
 use log::{error, info};
 use std::collections::HashSet;
-use std::error::Error;
 use std::fs;
 use std::io::BufRead;
 use std::path::Path;
+use std::sync::Arc;
 use tokio::sync::broadcast;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Client {
     pub(super) sender: mpsc::Sender<Command>,
+    bill_store: Arc<dyn BillStoreApi>,
 }
 
 impl Client {
-    pub fn new(sender: mpsc::Sender<Command>) -> Self {
-        Self { sender }
+    pub fn new(sender: mpsc::Sender<Command>, bill_store: Arc<dyn BillStoreApi>) -> Self {
+        Self { sender, bill_store }
     }
 
     pub async fn run(
@@ -166,7 +172,7 @@ impl Client {
 
             for file in fs::read_dir(BILLS_FOLDER_PATH).unwrap() {
                 let dir = file.unwrap();
-                if is_not_hidden(&dir) {
+                if is_not_hidden_or_directory(&dir) {
                     let bill_name = dir
                         .path()
                         .file_stem()
@@ -188,7 +194,7 @@ impl Client {
             let mut new_record = String::new();
             for file in fs::read_dir(BILLS_FOLDER_PATH).unwrap() {
                 let dir = file.unwrap();
-                if is_not_hidden(&dir) {
+                if is_not_hidden_or_directory(&dir) {
                     let bill_name = dir
                         .path()
                         .file_stem()
@@ -215,7 +221,7 @@ impl Client {
     pub async fn start_provide(&mut self) {
         for file in fs::read_dir(BILLS_FOLDER_PATH).unwrap() {
             let dir = file.unwrap();
-            if is_not_hidden(&dir) {
+            if is_not_hidden_or_directory(&dir) {
                 let bill_name = dir
                     .path()
                     .file_stem()
@@ -268,7 +274,7 @@ impl Client {
         identity_public_data
     }
 
-    pub async fn add_bill_to_dht_for_node(&mut self, bill_name: &String, node_id: &str) {
+    pub async fn add_bill_to_dht_for_node(&mut self, bill_name: &str, node_id: &str) {
         let node_request = BILLS_PREFIX.to_string() + node_id;
         let mut record_for_saving_in_dht;
         let list_bills_for_node = self.get_record(node_request.clone()).await;
@@ -281,7 +287,7 @@ impl Client {
                 record_for_saving_in_dht = record_for_saving_in_dht.to_string() + "," + bill_name;
             }
         } else {
-            record_for_saving_in_dht = bill_name.clone();
+            record_for_saving_in_dht = bill_name.to_owned();
         }
 
         if !std::str::from_utf8(&value)
@@ -330,6 +336,46 @@ impl Client {
                     .map_err(|_| "None of the providers returned file.")
                     .expect("Can not get file content.")
                     .0
+            }
+        }
+    }
+
+    /// Requests the given file for the given bill name, saving it once it arrives
+    pub async fn get_bill_attachment(
+        &mut self,
+        bill_name: String,
+        file_name: String,
+    ) -> Result<()> {
+        let local_peer_id = read_peer_id_from_file();
+        // TODO: check if there is a bill for this bill_name and if it has a file with this name
+        // -> read_bill_from_file into persistence
+        // TODO: get the hash here
+        let mut providers = self.get_providers(bill_name.to_owned()).await;
+        providers.remove(&local_peer_id);
+        if providers.is_empty() {
+            return Err(anyhow!("No providers found"));
+        }
+
+        let requests = providers.into_iter().map(|peer_id| {
+            let mut network_client = self.clone();
+            let file_request = file_request_for_bill_attachment(
+                &local_peer_id.to_string(),
+                &bill_name,
+                &file_name,
+            );
+            async move { network_client.request_file(peer_id, file_request).await }.boxed()
+        });
+
+        match futures::future::select_ok(requests).await {
+            Err(e) => Err(anyhow!(
+                "Get Bill Attachment: None of the providers returned the file: {e}"
+            )),
+            Ok(file_content) => {
+                self.bill_store.read_bill_keys_from_file(&bill_name).await?;
+                // TODO: decrypt using private identity key
+                // TODO: calculate the hash and check if hash matches the hash from the bill from above
+                // TODO: encrypt_and_save_attached_file
+                Ok(())
             }
         }
     }
@@ -445,11 +491,7 @@ impl Client {
         receiver.await.expect("Sender not to be dropped.")
     }
 
-    async fn request_file(
-        &mut self,
-        peer: PeerId,
-        file_name: String,
-    ) -> Result<Vec<u8>, Box<dyn Error + Send>> {
+    async fn request_file(&mut self, peer: PeerId, file_name: String) -> Result<Vec<u8>> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Command::RequestFile {
@@ -471,45 +513,83 @@ impl Client {
 
     async fn handle_event(&mut self, event: Event) {
         let Event::InboundRequest { request, channel } = event;
-        let size_request = request.split("_").collect::<Vec<&str>>();
-        if size_request.len().eq(&3) {
-            let request_node_id: String =
-                request.splitn(2, "_").collect::<Vec<&str>>()[0].to_string();
-            let request = request.splitn(2, "_").collect::<Vec<&str>>()[1].to_string();
-
-            let mut bill_name = request.clone();
-            if request.starts_with(KEY_PREFIX) {
-                bill_name = request.splitn(2, KEY_PREFIX).collect::<Vec<&str>>()[1].to_string();
-            } else if request.starts_with(BILL_PREFIX) {
-                bill_name = request.split(BILL_PREFIX).collect::<Vec<&str>>()[1].to_string();
+        match parse_inbound_file_request(&request) {
+            Err(e) => {
+                error!("Could not handle inbound request {request}: {e}")
             }
-            let chain = Chain::read_chain_from_file(&bill_name);
+            Ok(parsed) => {
+                match parsed {
+                    // We can send the bill to anyone requesting it, since the content is encrypted
+                    // and is useless without the keys
+                    ParsedInboundFileRequest::Bill(BillFileRequest { bill_name }) => {
+                        let path_to_bill = get_path_for_bill(&bill_name);
+                        match tokio::fs::read(&path_to_bill).await {
+                            Err(e) => {
+                                error!("Could not handle inbound request {request}: {e}")
+                            }
+                            Ok(file) => {
+                                self.respond_file(file, channel).await;
+                            }
+                        }
+                    }
+                    // We check if the requester is part of the bill and if so, we get their
+                    // identity from DHT and encrypt the file with their public key
+                    ParsedInboundFileRequest::BillKeys(BillKeysFileRequest {
+                        node_id,
+                        key_name,
+                    }) => {
+                        let chain = Chain::read_chain_from_file(&key_name);
+                        if chain.bill_contains_node(&node_id) {
+                            let public_key = self
+                                .get_identity_public_data_from_dht(node_id)
+                                .await
+                                .rsa_public_key_pem;
 
-            let bill_contain_node = chain.bill_contain_node(request_node_id.clone());
+                            let path_to_key = get_path_for_bill_keys(&key_name);
+                            match tokio::fs::read(&path_to_key).await {
+                                Err(e) => {
+                                    error!("Could not handle inbound request {request}: {e}")
+                                }
+                                Ok(file) => {
+                                    let file_encrypted =
+                                        encrypt_bytes_with_public_key(&file, &public_key);
 
-            if request.starts_with(KEY_PREFIX) {
-                if bill_contain_node {
-                    let public_key = self
-                        .get_identity_public_data_from_dht(request_node_id.clone())
-                        .await
-                        .rsa_public_key_pem;
+                                    self.respond_file(file_encrypted, channel).await;
+                                }
+                            }
+                        }
+                    }
+                    // We only send attachments (encrypted with the bill public key) to participants of the bill, encrypted with their public key
+                    ParsedInboundFileRequest::BillAttachment(BillAttachmentFileRequest {
+                        node_id,
+                        bill_name,
+                        file_name,
+                    }) => {
+                        let chain = Chain::read_chain_from_file(&bill_name);
+                        if chain.bill_contains_node(&node_id) {
+                            let public_key = self
+                                .get_identity_public_data_from_dht(node_id)
+                                .await
+                                .rsa_public_key_pem;
 
-                    let key_name =
-                        request.splitn(2, KEY_PREFIX).collect::<Vec<&str>>()[1].to_string();
-                    let path_to_key = get_path_for_bill_keys(&key_name);
-                    let file = fs::read(&path_to_key).unwrap();
+                            match self
+                                .bill_store
+                                .open_attached_file(&bill_name, &file_name)
+                                .await
+                            {
+                                Err(e) => {
+                                    error!("Could not handle inbound request {request}: {e}")
+                                }
+                                Ok(file) => {
+                                    let file_encrypted =
+                                        encrypt_bytes_with_public_key(&file, &public_key);
 
-                    let file_encrypted = encrypt_bytes_with_public_key(&file, public_key);
-
-                    self.respond_file(file_encrypted, channel).await;
+                                    self.respond_file(file_encrypted, channel).await;
+                                }
+                            }
+                        }
+                    }
                 }
-            } else if request.starts_with(BILL_PREFIX) {
-                let bill_name =
-                    request.splitn(2, BILL_PREFIX).collect::<Vec<&str>>()[1].to_string();
-                let path_to_bill = get_path_for_bill(&bill_name);
-                let file = fs::read(&path_to_bill).unwrap();
-
-                self.respond_file(file, channel).await;
             }
         }
     }
@@ -537,7 +617,7 @@ impl Client {
                     match args.next() {
                         Some(name) => String::from(name),
                         None => {
-                            error!("Expected name.");
+                            error!("Expected bill name.");
                             return;
                         }
                     }
@@ -545,12 +625,36 @@ impl Client {
                 self.get_bill(name).await;
             }
 
+            Some("GET_BILL_ATTACHMENT") => {
+                let name: String = {
+                    match args.next() {
+                        Some(name) => String::from(name),
+                        None => {
+                            error!("Expected bill name.");
+                            return;
+                        }
+                    }
+                };
+                let file_name: String = {
+                    match args.next() {
+                        Some(file_name) => String::from(file_name),
+                        None => {
+                            error!("Expected file name.");
+                            return;
+                        }
+                    }
+                };
+                if let Err(e) = self.get_bill_attachment(name, file_name).await {
+                    error!("Get Bill Attachment failed: {e}");
+                }
+            }
+
             Some("GET_KEY") => {
                 let name: String = {
                     match args.next() {
                         Some(name) => String::from(name),
                         None => {
-                            error!("Expected name.");
+                            error!("Expected bill name.");
                             return;
                         }
                     }
@@ -646,7 +750,7 @@ impl Client {
 
             _ => {
                 error!(
-                        "expected GET, PUT, SEND_MESSAGE, SUBSCRIBE, GET_RECORD, PUT_RECORD or GET_PROVIDERS."
+                        "expected GET_BILL, GET_KEY, GET_BILL_ATTACHMENT, PUT, SEND_MESSAGE, SUBSCRIBE, GET_RECORD, PUT_RECORD or GET_PROVIDERS."
                     );
             }
         }

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -4,6 +4,7 @@ use crate::constants::{
     RELAY_BOOTSTRAP_NODE_ONE_IP, RELAY_BOOTSTRAP_NODE_ONE_PEER_ID, RELAY_BOOTSTRAP_NODE_ONE_TCP,
 };
 use crate::dht::behaviour::{FileRequest, FileResponse};
+use anyhow::Result;
 use futures::channel::mpsc::Receiver;
 use futures::channel::{mpsc, oneshot};
 use futures::prelude::*;
@@ -20,13 +21,11 @@ use libp2p::swarm::{Swarm, SwarmEvent};
 use libp2p::{gossipsub, relay, PeerId};
 use log::{error, info, warn};
 use std::collections::{HashMap, HashSet};
-use std::error::Error;
 use std::iter;
 use tokio::sync::broadcast;
 
-type PendingDial = HashMap<PeerId, oneshot::Sender<Result<(), Box<dyn Error + Send>>>>;
-type PendingRequestFile =
-    HashMap<RequestId, oneshot::Sender<Result<Vec<u8>, Box<dyn Error + Send>>>>;
+type PendingDial = HashMap<PeerId, oneshot::Sender<Result<()>>>;
+type PendingRequestFile = HashMap<RequestId, oneshot::Sender<Result<Vec<u8>>>>;
 
 pub struct EventLoop {
     swarm: Swarm<MyBehaviour>,
@@ -196,7 +195,7 @@ impl EventLoop {
                     .pending_request_file
                     .remove(&request_id)
                     .expect("Request to still be pending.")
-                    .send(Err(Box::new(error)));
+                    .send(Err(error.into()));
             }
 
             SwarmEvent::Behaviour(ComposedEvent::RequestResponse(

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -79,6 +79,7 @@ impl EventLoop {
                 KademliaEvent::OutboundQueryProgressed { result, id, .. },
             )) => match result {
                 QueryResult::StartProviding(Ok(kad::AddProviderOk { key: _ })) => {
+                    info!("Successfully started providing query id: {id:?}");
                     let sender: oneshot::Sender<()> = self
                         .pending_start_providing
                         .remove(&id)

--- a/src/external/mod.rs
+++ b/src/external/mod.rs
@@ -1,3 +1,16 @@
 pub mod bitcoin;
 pub mod mint;
 pub mod time;
+
+use thiserror::Error;
+
+/// Generic result type
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Generic error type
+#[derive(Debug, Error)]
+pub enum Error {
+    /// all errors originating from the external time API
+    #[error("External Time API error: {0}")]
+    ExternalTimeApi(#[from] reqwest::Error),
+}

--- a/src/external/time.rs
+++ b/src/external/time.rs
@@ -1,21 +1,29 @@
 use super::Result;
 use serde::Deserialize;
 
-const URL: &str = "https://api.timezonedb.com/v2.1/get-time-zone?key=RQ6ZFDOXPVLR&format=json&by=zone&zone=Europe/Vienna";
-
 /// Documented at https://timezonedb.com/references/get-time-zone
 #[derive(Deserialize, Debug)]
 pub struct TimeApi {
     pub timestamp: i64,
 }
 
+#[cfg(not(test))]
 impl TimeApi {
     pub async fn get_atomic_time() -> Result<Self> {
-        reqwest::get(URL)
+        reqwest::get("https://api.timezonedb.com/v2.1/get-time-zone?key=RQ6ZFDOXPVLR&format=json&by=zone&zone=Europe/Vienna")
             .await
             .map_err(super::Error::ExternalTimeApi)?
             .json()
             .await
             .map_err(super::Error::ExternalTimeApi)
+    }
+}
+
+#[cfg(test)]
+impl TimeApi {
+    pub async fn get_atomic_time() -> Result<Self> {
+        Ok(TimeApi {
+            timestamp: 1731593928,
+        })
     }
 }

--- a/src/external/time.rs
+++ b/src/external/time.rs
@@ -1,3 +1,4 @@
+use super::Result;
 use serde::Deserialize;
 
 const URL: &str = "https://api.timezonedb.com/v2.1/get-time-zone?key=RQ6ZFDOXPVLR&format=json&by=zone&zone=Europe/Vienna";
@@ -9,12 +10,12 @@ pub struct TimeApi {
 }
 
 impl TimeApi {
-    pub async fn get_atomic_time() -> Self {
+    pub async fn get_atomic_time() -> Result<Self> {
         reqwest::get(URL)
             .await
-            .expect("Failed to send request")
+            .map_err(super::Error::ExternalTimeApi)?
             .json()
             .await
-            .expect("Failed to read response")
+            .map_err(super::Error::ExternalTimeApi)
     }
 }

--- a/src/persistence/bill.rs
+++ b/src/persistence/bill.rs
@@ -1,0 +1,126 @@
+use super::{file_storage_path, Result};
+use crate::bill::BillKeys;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use tokio::{
+    fs::{create_dir_all, read, write, File},
+    io::AsyncReadExt,
+};
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait BillStoreApi: Send + Sync {
+    /// Writes the given encrypted bytes of an attached file to disk
+    async fn save_attached_file(
+        &self,
+        encrypted_bytes: &[u8],
+        bill_name: &str,
+        file_name: &str,
+    ) -> Result<()>;
+
+    /// Opens the given attached file from disk
+    async fn open_attached_file(&self, bill_name: &str, file_name: &str) -> Result<Vec<u8>>;
+
+    /// Writes bill keys to file
+    async fn write_bill_keys_to_file(
+        &self,
+        bill_name: String,
+        private_key: String,
+        public_key: String,
+    ) -> Result<()>;
+
+    /// Reads bill keys from file
+    async fn read_bill_keys_from_file(&self, bill_name: &str) -> Result<BillKeys>;
+}
+
+#[derive(Clone)]
+pub struct FileBasedBillStore {
+    #[allow(dead_code)]
+    folder: String,
+    files_folder: String,
+    keys_folder: String,
+}
+
+impl FileBasedBillStore {
+    pub async fn new(
+        data_dir: &str,
+        path: &str,
+        files_path: &str,
+        keys_path: &str,
+    ) -> Result<Self> {
+        let folder = file_storage_path(data_dir, path).await?;
+        let files_folder = file_storage_path(&format!("{data_dir}/{files_path}"), path).await?;
+        let keys_folder = file_storage_path(data_dir, keys_path).await?;
+        Ok(Self {
+            folder,
+            files_folder,
+            keys_folder,
+        })
+    }
+
+    pub fn get_path_for_bill_keys(&self, key_name: &str) -> PathBuf {
+        let mut path = PathBuf::from(self.keys_folder.as_str()).join(key_name);
+        path.set_extension("json");
+        path
+    }
+}
+
+#[async_trait]
+impl BillStoreApi for FileBasedBillStore {
+    async fn save_attached_file(
+        &self,
+        encrypted_bytes: &[u8],
+        bill_name: &str,
+        file_name: &str,
+    ) -> Result<()> {
+        let dest_dir = Path::new(&self.files_folder).join(bill_name);
+        if !dest_dir.exists() {
+            create_dir_all(&dest_dir).await.map_err(super::Error::Io)?;
+        }
+        let dest_file = dest_dir.join(file_name);
+        write(dest_file, encrypted_bytes)
+            .await
+            .map_err(super::Error::Io)
+    }
+
+    async fn open_attached_file(&self, bill_name: &str, file_name: &str) -> Result<Vec<u8>> {
+        let folder = Path::new(&self.files_folder)
+            .join(bill_name)
+            .join(file_name);
+
+        let mut file = File::open(&folder).await.map_err(super::Error::Io)?;
+        let mut buf = Vec::new();
+
+        file.read_to_end(&mut buf).await.map_err(super::Error::Io)?;
+        Ok(buf)
+    }
+
+    async fn write_bill_keys_to_file(
+        &self,
+        bill_name: String,
+        private_key: String,
+        public_key: String,
+    ) -> Result<()> {
+        let keys: BillKeys = BillKeys {
+            private_key_pem: private_key,
+            public_key_pem: public_key,
+        };
+
+        let output_path = self.get_path_for_bill_keys(&bill_name);
+        tokio::fs::write(
+            output_path.clone(),
+            serde_json::to_string_pretty(&keys).map_err(super::Error::Json)?,
+        )
+        .await
+        .map_err(super::Error::Io)
+    }
+
+    async fn read_bill_keys_from_file(&self, bill_name: &str) -> Result<BillKeys> {
+        let input_path = self.get_path_for_bill_keys(bill_name);
+        let blockchain_from_file = read(&input_path).await.map_err(super::Error::Io)?;
+        serde_json::from_slice(blockchain_from_file.as_slice()).map_err(super::Error::Json)
+    }
+}

--- a/src/persistence/contact.rs
+++ b/src/persistence/contact.rs
@@ -22,54 +22,54 @@ pub struct FileBasedContactStore {
 
 /// Just some shortcuts for read and write here
 impl FileBasedContactStore {
-    pub fn new(data_dir: &str, path: &str, file_name: &str) -> Result<Self> {
-        let directory = file_storage_path(data_dir, path)?;
+    pub async fn new(data_dir: &str, path: &str, file_name: &str) -> Result<Self> {
+        let directory = file_storage_path(data_dir, path).await?;
         Ok(Self {
             file: format!("{}/{}", directory, file_name),
         })
     }
 
-    fn write(&self, contacts: HashMap<String, IdentityPublicData>) -> Result<()> {
-        write_contacts_map(&self.file, contacts)
+    async fn write(&self, contacts: HashMap<String, IdentityPublicData>) -> Result<()> {
+        write_contacts_map(&self.file, contacts).await
     }
 
-    fn read(&self) -> Result<HashMap<String, IdentityPublicData>> {
-        read_contacts_map(&self.file)
+    async fn read(&self) -> Result<HashMap<String, IdentityPublicData>> {
+        read_contacts_map(&self.file).await
     }
 }
 
 #[async_trait]
 impl ContactStoreApi for FileBasedContactStore {
     async fn get_map(&self) -> Result<HashMap<String, IdentityPublicData>> {
-        Ok(self.read()?)
+        Ok(self.read().await?)
     }
 
     async fn by_name(&self, name: &str) -> Result<Option<IdentityPublicData>> {
-        let contact = self.read()?.get(name).map(|e| e.to_owned());
+        let contact = self.read().await?.get(name).map(|e| e.to_owned());
         Ok(contact)
     }
 
     async fn insert(&self, name: &str, data: IdentityPublicData) -> Result<()> {
-        let mut current = self.read()?;
+        let mut current = self.read().await?;
         current.insert(name.to_owned(), data);
-        self.write(current)?;
+        self.write(current).await?;
         Ok(())
     }
 
     async fn delete(&self, name: &str) -> Result<()> {
-        let mut current = self.read()?;
+        let mut current = self.read().await?;
         current.remove(name);
-        self.write(current)?;
+        self.write(current).await?;
         Ok(())
     }
 
     async fn update_name(&self, name: &str, new_name: &str) -> Result<()> {
-        let mut all = self.read()?;
+        let mut all = self.read().await?;
         match all.get(name) {
             Some(identity) => {
                 all.insert(new_name.to_owned(), identity.to_owned());
                 all.remove(name);
-                self.write(all)?;
+                self.write(all).await?;
                 Ok(())
             }
             None => Err(Error::NoSuchEntity("contact".to_string(), name.to_string())),
@@ -82,23 +82,23 @@ impl ContactStoreApi for FileBasedContactStore {
     }
 }
 
-fn write_contacts_map(file: &str, map: HashMap<String, IdentityPublicData>) -> Result<()> {
+async fn write_contacts_map(file: &str, map: HashMap<String, IdentityPublicData>) -> Result<()> {
     let contacts_byte = to_vec(&map)?;
-    fs::write(file, contacts_byte)?;
+    tokio::fs::write(file, contacts_byte).await?;
     Ok(())
 }
 
-fn read_contacts_map(file: &str) -> Result<HashMap<String, IdentityPublicData>> {
+async fn read_contacts_map(file: &str) -> Result<HashMap<String, IdentityPublicData>> {
     if !Path::new(file).exists() {
-        create_contacts_map(file)?;
+        create_contacts_map(file).await?;
     }
     let data: Vec<u8> = fs::read(file)?;
     let contacts: HashMap<String, IdentityPublicData> = HashMap::try_from_slice(&data)?;
     Ok(contacts)
 }
 
-fn create_contacts_map(file: &str) -> Result<()> {
+async fn create_contacts_map(file: &str) -> Result<()> {
     let contacts: HashMap<String, IdentityPublicData> = HashMap::new();
-    write_contacts_map(file, contacts)?;
+    write_contacts_map(file, contacts).await?;
     Ok(())
 }

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -1,0 +1,456 @@
+use super::contact_service::IdentityPublicData;
+use super::Result;
+use crate::bill::identity::IdentityWithAll;
+use crate::bill::{accept_bill, BillFile, BillKeys};
+use crate::blockchain::{
+    start_blockchain_for_new_bill, Chain, GossipsubEvent, GossipsubEventId, OperationCode,
+};
+use crate::constants::{
+    COMPOUNDING_INTEREST_RATE_ZERO, MAX_FILE_NAME_CHARACTERS, MAX_FILE_SIZE_BYTES, USEDNET,
+    VALID_FILE_MIME_TYPES,
+};
+use crate::{bill::BitcreditBill, dht::Client, persistence::bill::BillStoreApi};
+use crate::{external, persistence, util};
+use async_trait::async_trait;
+use chrono::Utc;
+use log::{error, info};
+use openssl::pkey::Private;
+use openssl::rsa::Rsa;
+use openssl::sha::sha256;
+use rocket::fs::TempFile;
+use std::sync::Arc;
+use tokio::io::AsyncReadExt;
+
+#[async_trait]
+pub trait BillServiceApi: Send + Sync {
+    /// Gets the keys for a given bill
+    async fn get_bill_keys(&self, bill_name: &str) -> Result<BillKeys>;
+
+    /// opens and decrypts the attached file from the given bill
+    async fn open_and_decrypt_attached_file(
+        &self,
+        bill_name: &str,
+        file_name: &str,
+        bill_private_key: &str,
+    ) -> Result<Vec<u8>>;
+
+    /// encrypts and saves the given uploaded file, returning the file name, as well as the hash of
+    /// the unencrypted file
+    async fn encrypt_and_save_uploaded_file(
+        &self,
+        file: &dyn util::file::UploadFileHandler,
+        bill_name: &str,
+        bill_public_key: &str,
+    ) -> Result<BillFile>;
+
+    async fn validate_attached_file(&self, file: &TempFile) -> Result<()>;
+
+    async fn issue_new_bill(
+        &self,
+        bill_jurisdiction: String,
+        place_of_drawing: String,
+        amount_numbers: u64,
+        place_of_payment: String,
+        maturity_date: String,
+        currency_code: String,
+        drawer: IdentityWithAll,
+        language: String,
+        public_data_drawee: IdentityPublicData,
+        public_data_payee: IdentityPublicData,
+        files: &[TempFile],
+    ) -> Result<BitcreditBill>;
+
+    async fn propagate_bill(
+        &self,
+        bill_name: &str,
+        drawer_peer_id: &str,
+        drawee_peer_id: &str,
+        payee_peer_id: &str,
+    ) -> Result<()>;
+
+    async fn accept_bill(&self, bill_name: &str) -> Result<()>;
+}
+
+/// The bill service is responsible for all bill-related logic and for syncing them with the dht data.
+#[derive(Clone)]
+pub struct BillService {
+    client: Client,
+    store: Arc<dyn BillStoreApi>,
+}
+
+impl BillService {
+    pub fn new(client: Client, store: Arc<dyn BillStoreApi>) -> Self {
+        Self { client, store }
+    }
+}
+
+#[async_trait]
+impl BillServiceApi for BillService {
+    async fn get_bill_keys(&self, bill_name: &str) -> Result<BillKeys> {
+        let keys = self.store.read_bill_keys_from_file(bill_name).await?;
+        Ok(keys)
+    }
+
+    async fn open_and_decrypt_attached_file(
+        &self,
+        bill_name: &str,
+        file_name: &str,
+        bill_private_key: &str,
+    ) -> Result<Vec<u8>> {
+        let read_file = self.store.open_attached_file(bill_name, file_name).await?;
+        let decrypted =
+            util::rsa::decrypt_bytes_with_private_key(&read_file, bill_private_key.to_owned());
+        Ok(decrypted)
+    }
+
+    async fn encrypt_and_save_uploaded_file(
+        &self,
+        file: &dyn util::file::UploadFileHandler,
+        bill_name: &str,
+        bill_public_key: &str,
+    ) -> Result<BillFile> {
+        let read_file = file.get_contents().await.map_err(persistence::Error::Io)?;
+        let file_name = util::file::generate_unique_filename(
+            &util::file::sanitize_filename(
+                &file
+                    .name()
+                    .ok_or(super::Error::Validation(String::from("Invalid file name")))?,
+            ),
+            file.extension(),
+        );
+
+        let file_hash = hex::encode(sha256(&read_file));
+        let encrypted = util::rsa::encrypt_bytes_with_public_key(&read_file, bill_public_key);
+        self.store
+            .save_attached_file(&encrypted, bill_name, &file_name)
+            .await?;
+        info!("Saved file {file_name} with hash {file_hash} for bill {bill_name}");
+        Ok(BillFile {
+            name: file_name.to_owned(),
+            hash: file_hash,
+        })
+    }
+
+    async fn validate_attached_file(&self, file: &TempFile) -> Result<()> {
+        if file.len() > MAX_FILE_SIZE_BYTES as u64 {
+            return Err(super::Error::Validation(format!(
+                "Maximum file size is {} bytes",
+                MAX_FILE_SIZE_BYTES
+            )));
+        }
+
+        let name = match file.name() {
+            Some(n) => n,
+            None => {
+                return Err(super::Error::Validation(String::from(
+                    "File name needs to be set",
+                )));
+            }
+        };
+
+        if name.is_empty() || name.len() > MAX_FILE_NAME_CHARACTERS {
+            return Err(super::Error::Validation(format!(
+                "File name needs to have between 1 and {} characters",
+                MAX_FILE_NAME_CHARACTERS
+            )));
+        }
+
+        let mut buffer = vec![0; 256];
+        let mut opened = file.open().await.map_err(|e| {
+            error!("Error opening file during upload: {e}");
+            super::Error::Validation(String::from("File could not be opened"))
+        })?;
+        let bytes_read = opened.read(&mut buffer).await.map_err(|e| {
+            error!("Error reading file during upload: {e}");
+            super::Error::Validation(String::from("File could not be read"))
+        })?;
+
+        let detected_type = match infer::get(&buffer[..bytes_read]) {
+            Some(t) => t,
+            None => {
+                return Err(super::Error::Validation(String::from(
+                    "Unknown file type detected",
+                )))
+            }
+        };
+        if !VALID_FILE_MIME_TYPES.contains(&detected_type.mime_type()) {
+            return Err(super::Error::Validation(String::from(
+                "Invalid file type detected",
+            )));
+        }
+        Ok(())
+    }
+
+    async fn issue_new_bill(
+        &self,
+        bill_jurisdiction: String,
+        place_of_drawing: String,
+        amount_numbers: u64,
+        place_of_payment: String,
+        maturity_date: String,
+        currency_code: String,
+        drawer: IdentityWithAll,
+        language: String,
+        public_data_drawee: IdentityPublicData,
+        public_data_payee: IdentityPublicData,
+        files: &[TempFile],
+    ) -> Result<BitcreditBill> {
+        let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
+        let s = bitcoin::secp256k1::Secp256k1::new();
+        let private_key = bitcoin::PrivateKey::new(
+            s.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
+                .0,
+            USEDNET,
+        );
+        let public_key = private_key.public_key(&s);
+
+        let bill_name = hex::encode(sha256(&public_key.to_bytes()));
+
+        let private_key_bitcoin: String = private_key.to_string();
+        let public_key_bitcoin: String = public_key.to_string();
+
+        let rsa: Rsa<Private> = util::rsa::generation_rsa_key();
+        let private_key_pem: String = util::rsa::pem_private_key_from_rsa(&rsa);
+        let public_key_pem: String = util::rsa::pem_public_key_from_rsa(&rsa);
+        self.store
+            .write_bill_keys_to_file(
+                bill_name.clone(),
+                private_key_pem.clone(),
+                public_key_pem.clone(),
+            )
+            .await?;
+
+        let amount_letters: String = util::numbers_to_words::encode(&amount_numbers);
+
+        let public_data_drawer =
+            IdentityPublicData::new(drawer.identity.clone(), drawer.peer_id.to_string());
+
+        let utc = Utc::now();
+        let date_of_issue = utc.naive_local().date().to_string();
+
+        let to_payee = public_data_drawer == public_data_payee;
+
+        let mut bill_files: Vec<BillFile> = Vec::with_capacity(files.len());
+
+        for file in files {
+            bill_files.push(
+                self.encrypt_and_save_uploaded_file(file, &bill_name, &public_key_pem)
+                    .await?,
+            );
+        }
+
+        let bill = BitcreditBill {
+            name: bill_name,
+            to_payee,
+            bill_jurisdiction,
+            timestamp_at_drawing: timestamp,
+            place_of_drawing,
+            currency_code,
+            amount_numbers,
+            amounts_letters: amount_letters,
+            maturity_date,
+            date_of_issue,
+            compounding_interest_rate: COMPOUNDING_INTEREST_RATE_ZERO,
+            type_of_interest_calculation: false,
+            place_of_payment,
+            public_key: public_key_bitcoin,
+            private_key: private_key_bitcoin,
+            language,
+            drawee: public_data_drawee,
+            drawer: public_data_drawer.clone(),
+            payee: public_data_payee,
+            endorsee: IdentityPublicData::new_empty(),
+            files: bill_files,
+        };
+
+        start_blockchain_for_new_bill(
+            &bill,
+            OperationCode::Issue,
+            public_data_drawer,
+            drawer.identity.public_key_pem,
+            drawer.identity.private_key_pem,
+            private_key_pem,
+            timestamp,
+        );
+
+        Ok(bill)
+    }
+
+    async fn propagate_bill(
+        &self,
+        bill_name: &str,
+        drawer_peer_id: &str,
+        drawee_peer_id: &str,
+        payee_peer_id: &str,
+    ) -> Result<()> {
+        let mut client = self.client.clone();
+
+        for node in [drawer_peer_id, drawee_peer_id, payee_peer_id] {
+            if !node.is_empty() {
+                info!("issue bill: add {} for node {}", bill_name, &node);
+                client.add_bill_to_dht_for_node(bill_name, node).await;
+            }
+        }
+
+        client.subscribe_to_topic(bill_name.to_owned()).await;
+
+        client.put(bill_name).await;
+        Ok(())
+    }
+
+    async fn accept_bill(&self, bill_name: &str) -> Result<()> {
+        let mut client = self.client.clone();
+        let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
+
+        if accept_bill(bill_name, timestamp).await {
+            let chain: Chain = Chain::read_chain_from_file(bill_name);
+            let block = chain.get_latest_block();
+
+            let block_bytes = serde_json::to_vec(block)?;
+            let event = GossipsubEvent::new(GossipsubEventId::Block, block_bytes);
+
+            client
+                .add_message_to_topic(event.to_byte_array(), bill_name.to_owned())
+                .await;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tests::test::{TEST_PRIVATE_KEY, TEST_PUB_KEY};
+    use core::str;
+    use futures::channel::mpsc;
+    use mockall::predicate::{always, eq};
+    use persistence::bill::MockBillStoreApi;
+    use std::sync::Arc;
+    use util::file::MockUploadFileHandler;
+
+    fn get_service(mock_storage: MockBillStoreApi) -> BillService {
+        let (sender, _) = mpsc::channel(0);
+        BillService::new(
+            Client::new(sender, Arc::new(MockBillStoreApi::new())),
+            Arc::new(mock_storage),
+        )
+    }
+
+    #[tokio::test]
+    async fn save_encrypt_open_decrypt_compare_hashes() {
+        let bill_name = "test_bill_name";
+        let expected_file_name = "invoice_00000000-0000-0000-0000-000000000000.pdf";
+        let file_bytes = String::from("hello world").as_bytes().to_vec();
+        let expected_encrypted =
+            util::rsa::encrypt_bytes_with_public_key(&file_bytes, TEST_PUB_KEY);
+
+        let mut storage = MockBillStoreApi::new();
+        storage
+            .expect_save_attached_file()
+            .with(always(), eq(bill_name), eq(expected_file_name))
+            .times(1)
+            .returning(|_, _, _| Ok(()));
+
+        storage
+            .expect_open_attached_file()
+            .with(eq(bill_name), eq(expected_file_name))
+            .times(1)
+            .returning(move |_, _| Ok(expected_encrypted.clone()));
+        let service = get_service(storage);
+
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name()
+            .returning(|| Some(String::from("invoice")));
+        file.expect_extension()
+            .returning(|| Some(String::from("pdf")));
+        file.expect_get_contents()
+            .returning(move || Ok(file_bytes.clone()));
+
+        let bill_file = service
+            .encrypt_and_save_uploaded_file(&file, bill_name, TEST_PUB_KEY)
+            .await
+            .unwrap();
+        assert_eq!(
+            bill_file.hash,
+            String::from("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+        );
+        assert_eq!(bill_file.name, String::from(expected_file_name));
+
+        let decrypted = service
+            .open_and_decrypt_attached_file(bill_name, expected_file_name, TEST_PRIVATE_KEY)
+            .await
+            .unwrap();
+        assert_eq!(str::from_utf8(&decrypted).unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn save_encrypt_propagates_read_file_error() {
+        let storage = MockBillStoreApi::new();
+        let service = get_service(storage);
+
+        let mut file = MockUploadFileHandler::new();
+        file.expect_get_contents()
+            .returning(|| Err(std::io::Error::new(std::io::ErrorKind::Other, "test error")));
+
+        assert!(service
+            .encrypt_and_save_uploaded_file(&file, "test", TEST_PUB_KEY)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn save_encrypt_propagates_write_file_error() {
+        let mut storage = MockBillStoreApi::new();
+        storage.expect_save_attached_file().returning(|_, _, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage);
+
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name()
+            .returning(|| Some(String::from("invoice")));
+        file.expect_extension()
+            .returning(|| Some(String::from("pdf")));
+        file.expect_get_contents().returning(|| Ok(vec![]));
+
+        assert!(service
+            .encrypt_and_save_uploaded_file(&file, "test", TEST_PUB_KEY)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn save_encrypt_propagates_file_name_error() {
+        let storage = MockBillStoreApi::new();
+        let service = get_service(storage);
+
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name().returning(|| None);
+        file.expect_get_contents().returning(|| Ok(vec![]));
+
+        assert!(service
+            .encrypt_and_save_uploaded_file(&file, "test", TEST_PUB_KEY)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn open_decrypt_propagates_read_file_error() {
+        let mut storage = MockBillStoreApi::new();
+        storage.expect_open_attached_file().returning(|_, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage);
+
+        assert!(service
+            .open_and_decrypt_attached_file("test", "test", TEST_PRIVATE_KEY)
+            .await
+            .is_err());
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,14 +1,54 @@
 #[cfg(test)]
-mod test {
-    use crate::external::bitcoin::AddressInfo;
+pub mod test {
     use crate::util::rsa::generation_rsa_key;
-    use bitcoin::secp256k1::Scalar;
     use libp2p::identity::Keypair;
     use libp2p::PeerId;
-    use log::info;
+
     use openssl::rsa::{Padding, Rsa};
     use std::fs;
     use std::path::Path;
+
+    pub const TEST_PUB_KEY: &str = r#"
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAubhgUJO9PWBZK2CfqSJr
+v3RlDeF3TWiXBocWmBJXzQe4F8qfbj8nTHYJ0Eh22uPVg/Meul/3WNitFMU93jTL
+hnYsx5qxOTHpQ8PVh1+2WvkpIfvJYBVuvmFMtFliyPuJKrOSGJp3SP5EgXbhSI+0
+BB9y/pF5E0fZbh7Nwlci1R4L+dmuW0raPxgSgQw+g3KeBc+DiFEvJJ/ZuoaukS0h
+UwDwY/QdSYRDNHNNO1W4hFJJj1dqnwfs/OmK8yWOG1GjJpI4TYnn/UO6ZJkTkTbA
+xWiIC5Q+ZwzlYEJMNIBTBz+KKTUr4BeJEdneznUb0yeBzcdCg5EHQlvv7plXsQju
+DQIDAQAB
+-----END PUBLIC KEY-----
+"#;
+
+    pub const TEST_PRIVATE_KEY: &str = r#"
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAubhgUJO9PWBZK2CfqSJrv3RlDeF3TWiXBocWmBJXzQe4F8qf
+bj8nTHYJ0Eh22uPVg/Meul/3WNitFMU93jTLhnYsx5qxOTHpQ8PVh1+2WvkpIfvJ
+YBVuvmFMtFliyPuJKrOSGJp3SP5EgXbhSI+0BB9y/pF5E0fZbh7Nwlci1R4L+dmu
+W0raPxgSgQw+g3KeBc+DiFEvJJ/ZuoaukS0hUwDwY/QdSYRDNHNNO1W4hFJJj1dq
+nwfs/OmK8yWOG1GjJpI4TYnn/UO6ZJkTkTbAxWiIC5Q+ZwzlYEJMNIBTBz+KKTUr
+4BeJEdneznUb0yeBzcdCg5EHQlvv7plXsQjuDQIDAQABAoIBABgwJr8n1rxBKavo
+HDNDi+P2DVlG9apLxmuvuWYZ8Xx/Fl9m4OfTatNfBj0tyukMRlk2l1hvuj/EjJpJ
+bBreJmm/R2rBv3YzBW3xegR1F0N28v/9kockk3VRJ9PPVnnVpNI+a/cvWvzTPOnd
+qU6xhKEK1YfJO4sizvM0KNk4Tw2RcE08o7tcDxQY6VO94dbaZ8ZJ2V+saiAa5BqN
+cVZ+uZBmriJg+MVeB2PECqAGJWJ98r8I1Tq+2aRBc1+94E8Ilfi54qp4jpTghw3y
+LH/uyf3BsbY4j08gk0Y7ljoXmaVyR7BZhcSOhc3XvMAzoqRzQpu/Fexk3Db6fuXz
+wxvUW6ECgYEA/YTnhDbUS7r5ze7ntNQpuZZ3F9vU/FG2c+iC/MJ4Z2wb0gUJ8dXG
+8Zbx7fQE3Hs44bW50tUaTvg7UsvyLMun6/OhdDgS+HGbMhJDNOBHQ3I1QKYUulbt
+ZxRqt8dJRqOi5ctp0+zsFTko0lgA9BlIqG07oXNWzUS8Cf9DsBSaAn0CgYEAu4mg
+oZok/ohv+//sb0T0UzDlxRSUf5a7Q2A0+a+hyMJm5QYHc+slLLsUdUapsx8tu71B
+Y29J7+yfttH4R1NTP1cOPJj5edt+qknuQ0hMZKt+CS4ItxMM/bHV2z+Oi0U/LoW8
+4jo2hh2oaHdXiDlXT9Eds7RK0vTrpcw5Q95fXtECgYAow7gecFqOmtAUJvgnAX58
+Ew+vTG/g6pq15Is7bWHC74VBrgG9WyyUKDtakcQ+V6n70SbCGfYTAKM5WwXj4hNs
+Q06Qy3txa4MS+BDKbc3HsJOTg6ENnXCrBINsbaUAsMs+vAiWRSBpATnpKLFujqo6
+OuY9vbgVZZn+2Ybex1FEWQKBgQCAOqN9u9MtwwanDR+SGVjiBR4memLrNppGgGLY
+kvGRPvNyB4RTC2Z4xlY/thhUpK31n3s1TSQGDApMzBbyVhQmzBSs9IAohR9/ultS
+3/10HBpqlnJZE4qfcNhkOHnz2l5QJhu3p8weOesruuY7+9EqfzbK6Cz9P4Bc9l31
+fPhC8QKBgQCO5FYksuRclILpzSVIJRj68NXZaLknDwAiNqb1a2diqGMCASXC5Z/U
+jS4/cHdsAfssbxRGpoM5WNU7QPa/vhCVygcmAPPBD0DLT16JGpcnuAy3Ae4ss3Ih
+HnZAVCxlGQ7ooHRIxJnp09ogDo7cDIevyMn1VmIZDm9JR1TUL6pbsg==
+-----END RSA PRIVATE KEY-----
+    "#;
 
     // fn bill_to_byte_array(bill: &BitcreditBill) -> Vec<u8> {
     //     to_vec(bill).unwrap()
@@ -181,41 +221,41 @@ mod test {
     //     assert_eq!(bill.bill_jurisdiction, "bill.bill_jurisdiction".to_string());
     // }
 
-    #[test]
-    fn test_bitcoin() {
-        let _ = env_logger::try_init();
-        let s1 = bitcoin::secp256k1::Secp256k1::new();
-        let private_key1 = bitcoin::PrivateKey::new(
-            s1.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
-                .0,
-            bitcoin::Network::Testnet,
-        );
-        let public_key1 = private_key1.public_key(&s1);
-        let _address1 = bitcoin::Address::p2pkh(public_key1, bitcoin::Network::Testnet);
+    // #[test]
+    // fn test_bitcoin() {
+    //     let _ = env_logger::try_init();
+    //     let s1 = bitcoin::secp256k1::Secp256k1::new();
+    //     let private_key1 = bitcoin::PrivateKey::new(
+    //         s1.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
+    //             .0,
+    //         bitcoin::Network::Testnet,
+    //     );
+    //     let public_key1 = private_key1.public_key(&s1);
+    //     let _address1 = bitcoin::Address::p2pkh(public_key1, bitcoin::Network::Testnet);
 
-        let s2 = bitcoin::secp256k1::Secp256k1::new();
-        let private_key2 = bitcoin::PrivateKey::new(
-            s2.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
-                .0,
-            bitcoin::Network::Testnet,
-        );
-        let public_key2 = private_key1.public_key(&s2);
-        let _address2 = bitcoin::Address::p2pkh(public_key2, bitcoin::Network::Testnet);
+    //     let s2 = bitcoin::secp256k1::Secp256k1::new();
+    //     let private_key2 = bitcoin::PrivateKey::new(
+    //         s2.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
+    //             .0,
+    //         bitcoin::Network::Testnet,
+    //     );
+    //     let public_key2 = private_key1.public_key(&s2);
+    //     let _address2 = bitcoin::Address::p2pkh(public_key2, bitcoin::Network::Testnet);
 
-        let private_key3 = private_key1
-            .inner
-            .add_tweak(&Scalar::from(private_key2.inner))
-            .unwrap();
-        let pr_key3 = bitcoin::PrivateKey::new(private_key3, bitcoin::Network::Testnet);
-        let public_key3 = public_key1.inner.combine(&public_key2.inner).unwrap();
-        let pub_key3 = bitcoin::PublicKey::new(public_key3);
-        let address3 = bitcoin::Address::p2pkh(pub_key3, bitcoin::Network::Testnet);
+    //     let private_key3 = private_key1
+    //         .inner
+    //         .add_tweak(&Scalar::from(private_key2.inner))
+    //         .unwrap();
+    //     let pr_key3 = bitcoin::PrivateKey::new(private_key3, bitcoin::Network::Testnet);
+    //     let public_key3 = public_key1.inner.combine(&public_key2.inner).unwrap();
+    //     let pub_key3 = bitcoin::PublicKey::new(public_key3);
+    //     let address3 = bitcoin::Address::p2pkh(pub_key3, bitcoin::Network::Testnet);
 
-        info!("private key: {}", pr_key3);
-        info!("public key: {}", pub_key3);
-        info!("address: {}", address3);
-        info!("{}", address3.is_spend_standard());
-    }
+    //     info!("private key: {}", pr_key3);
+    //     info!("public key: {}", pub_key3);
+    //     info!("address: {}", address3);
+    //     info!("{}", address3.is_spend_standard());
+    // }
 
     // #[tokio::test]
     // async fn test_mint() {
@@ -368,29 +408,29 @@ mod test {
     //     assert_ne!(1, balance);
     // }
 
-    #[tokio::test]
-    async fn test_api() {
-        let _ = env_logger::try_init();
-        let request_url = format!(
-            "https://blockstream.info/testnet/api/address/{address}",
-            address = "mzYHxNxTTGrrxnwSc1RvqTusK4EM88o6yj"
-        );
-        info!("{}", request_url);
-        let response1 = reqwest::get(&request_url)
-            .await
-            .expect("Failed to send request")
-            .text()
-            .await
-            .expect("Failed to read response");
-        info!("{:?}", response1);
-        let response: AddressInfo = reqwest::get(&request_url)
-            .await
-            .expect("Failed to send request")
-            .json()
-            .await
-            .expect("Failed to read response");
-        info!("{:?}", response);
-    }
+    // #[tokio::test]
+    // async fn test_api() {
+    //     let _ = env_logger::try_init();
+    //     let request_url = format!(
+    //         "https://blockstream.info/testnet/api/address/{address}",
+    //         address = "mzYHxNxTTGrrxnwSc1RvqTusK4EM88o6yj"
+    //     );
+    //     info!("{}", request_url);
+    //     let response1 = reqwest::get(&request_url)
+    //         .await
+    //         .expect("Failed to send request")
+    //         .text()
+    //         .await
+    //         .expect("Failed to read response");
+    //     info!("{:?}", response1);
+    //     let response: AddressInfo = reqwest::get(&request_url)
+    //         .await
+    //         .expect("Failed to send request")
+    //         .json()
+    //         .await
+    //         .expect("Failed to read response");
+    //     info!("{:?}", response);
+    // }
 
     #[test]
     fn test_schnorr() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,6 @@
 #[cfg(test)]
 mod test {
     use crate::external::bitcoin::AddressInfo;
-    use crate::util::numbers_to_words::encode;
     use crate::util::rsa::generation_rsa_key;
     use bitcoin::secp256k1::Scalar;
     use libp2p::identity::Keypair;
@@ -611,11 +610,5 @@ mod test {
             .private_decrypt(&data_enc, &mut buf, Padding::PKCS1)
             .unwrap();
         assert!(String::from_utf8(buf).unwrap().starts_with(data));
-    }
-
-    #[test]
-    fn numbers_to_letters() {
-        let result = encode(&123_324_324);
-        assert_eq!("one hundred twenty-three million three hundred twenty-four thousand three hundred twenty-four".to_string(), result);
     }
 }

--- a/src/util/file.rs
+++ b/src/util/file.rs
@@ -1,0 +1,134 @@
+use async_trait::async_trait;
+use rocket::{fs::TempFile, http::ContentType};
+use std::{ffi::OsStr, fs::DirEntry, path::Path};
+use tokio::io::AsyncReadExt;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait UploadFileHandler: Send + Sync {
+    /// Read the attached uploaded file
+    async fn get_contents(&self) -> std::io::Result<Vec<u8>>;
+    /// Returns the extension for an uploaded file
+    fn extension(&self) -> Option<String>;
+    /// Returns the name for an uploaded file
+    fn name(&self) -> Option<String>;
+}
+
+#[async_trait]
+impl UploadFileHandler for TempFile<'_> {
+    async fn get_contents(&self) -> std::io::Result<Vec<u8>> {
+        let mut opened = self.open().await?;
+        let mut buf = Vec::with_capacity(self.len() as usize);
+        opened.read_to_end(&mut buf).await?;
+        Ok(buf)
+    }
+
+    fn extension(&self) -> Option<String> {
+        self.content_type()
+            .and_then(|c| c.extension().map(|e| e.to_string()))
+    }
+
+    fn name(&self) -> Option<String> {
+        self.name().map(|s| s.to_owned())
+    }
+}
+/// Function to sanitize the filename by removing unwanted characters.
+pub fn sanitize_filename(filename: &str) -> String {
+    filename
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '.' || *c == '-' || *c == '_')
+        .collect()
+}
+
+pub fn detect_content_type_for_bytes(bytes: &[u8]) -> Option<ContentType> {
+    if bytes.len() < 256 {
+        return None; // can't decide with so few bytes
+    }
+    infer::get(&bytes[..256]).and_then(|t| ContentType::parse_flexible(t.mime_type()))
+}
+
+/// Function to generate a unique filename using UUID while preserving the file extension.
+pub fn generate_unique_filename(original_filename: &str, extension: Option<String>) -> String {
+    let path = Path::new(original_filename);
+    let stem = path.file_stem().and_then(OsStr::to_str).unwrap_or("");
+    let extension = extension.unwrap_or_default();
+    let optional_dot = if extension.is_empty() { "" } else { "." };
+    format!(
+        "{}_{}{}{}",
+        stem,
+        super::get_uuid_v4(),
+        optional_dot,
+        extension
+    )
+}
+
+/// Function to make sure a given file is neither hidden, nor a directory
+pub fn is_not_hidden_or_directory(entry: &DirEntry) -> bool {
+    let file_type = match entry.file_type() {
+        Err(_) => return false,
+        Ok(t) => t,
+    };
+
+    if file_type.is_dir() {
+        return false;
+    }
+
+    match hf::is_hidden(entry.path()) {
+        Ok(res) => !res,
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn sanitize_filename_basic() {
+        assert_eq!(
+            sanitize_filename("FI$$LE()()NAME.PD@@@F"),
+            String::from("filename.pdf")
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_empty() {
+        assert_eq!(sanitize_filename(""), String::from(""));
+    }
+
+    #[test]
+    fn sanitize_filename_sane() {
+        assert_eq!(
+            sanitize_filename("invoice-october_2024.pdf"),
+            String::from("invoice-october_2024.pdf")
+        );
+    }
+
+    #[test]
+    fn generate_unique_filename_basic() {
+        assert_eq!(
+            generate_unique_filename("file_name.pdf", Some(String::from("pdf"))),
+            String::from("file_name_00000000-0000-0000-0000-000000000000.pdf")
+        );
+    }
+
+    #[test]
+    fn generate_unique_filename_no_ext() {
+        assert_eq!(
+            generate_unique_filename("file_name", None),
+            String::from("file_name_00000000-0000-0000-0000-000000000000")
+        );
+    }
+
+    #[test]
+    fn generate_unique_filename_multi_ext() {
+        assert_eq!(
+            generate_unique_filename("file_name", Some(String::from("tar.gz"))),
+            String::from("file_name_00000000-0000-0000-0000-000000000000.tar.gz")
+        );
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,11 +1,15 @@
-use std::fs::DirEntry;
-
+pub mod file;
 pub mod numbers_to_words;
 pub mod rsa;
+use uuid::Uuid;
 
-pub fn is_not_hidden(entry: &DirEntry) -> bool {
-    match hf::is_hidden(entry.path()) {
-        Ok(res) => !res,
-        Err(_) => false,
-    }
+#[cfg(not(test))]
+pub fn get_uuid_v4() -> Uuid {
+    Uuid::new_v4()
+}
+
+#[cfg(test)]
+pub fn get_uuid_v4() -> Uuid {
+    use uuid::uuid;
+    uuid!("00000000-0000-0000-0000-000000000000")
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,7 @@
 pub mod file;
 pub mod numbers_to_words;
 pub mod rsa;
+use openssl::sha::sha256;
 use uuid::Uuid;
 
 #[cfg(not(test))]
@@ -12,4 +13,8 @@ pub fn get_uuid_v4() -> Uuid {
 pub fn get_uuid_v4() -> Uuid {
     use uuid::uuid;
     uuid!("00000000-0000-0000-0000-000000000000")
+}
+
+pub fn sha256_hash(bytes: &[u8]) -> String {
+    hex::encode(sha256(bytes))
 }

--- a/src/util/numbers_to_words.rs
+++ b/src/util/numbers_to_words.rs
@@ -65,3 +65,32 @@ fn format_num(num: &u64, div: u64, order: &str) -> String {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn numbers_to_letters_one() {
+        let result = encode(&5);
+        assert_eq!("five".to_string(), result);
+    }
+
+    #[test]
+    fn numbers_to_letters_zero() {
+        let result = encode(&0);
+        assert_eq!("zero".to_string(), result);
+    }
+
+    #[test]
+    fn numbers_to_letters_few() {
+        let result = encode(&999);
+        assert_eq!("nine hundred ninety-nine".to_string(), result);
+    }
+
+    #[test]
+    fn numbers_to_letters_many() {
+        let result = encode(&123_324_324);
+        assert_eq!("one hundred twenty-three million three hundred twenty-four thousand three hundred twenty-four".to_string(), result);
+    }
+}

--- a/src/util/rsa.rs
+++ b/src/util/rsa.rs
@@ -27,7 +27,7 @@ pub fn public_key_from_pem_u8(public_key_u8: &[u8]) -> Rsa<Public> {
 //--------------------------------------------------------------
 
 //-------------------------Bytes common-------------------------
-pub fn encrypt_bytes_with_public_key(bytes: &[u8], public_key: String) -> Vec<u8> {
+pub fn encrypt_bytes_with_public_key(bytes: &[u8], public_key: &str) -> Vec<u8> {
     let public_key = Rsa::public_key_from_pem(public_key.as_bytes()).unwrap();
 
     let key_size: usize = (public_key.size() / 2) as usize; //128

--- a/src/web/data.rs
+++ b/src/web/data.rs
@@ -1,9 +1,9 @@
+use rocket::fs::TempFile;
 use rocket::serde::{Deserialize, Serialize};
 use rocket::FromForm;
 
-#[derive(FromForm, Debug, Serialize, Deserialize)]
-#[serde(crate = "rocket::serde")]
-pub struct BitcreditBillForm {
+#[derive(FromForm, Debug)]
+pub struct BitcreditBillForm<'r> {
     pub bill_jurisdiction: String,
     pub place_of_drawing: String,
     pub currency_code: String,
@@ -15,6 +15,7 @@ pub struct BitcreditBillForm {
     pub maturity_date: String,
     pub drawer_is_payee: bool,
     pub drawer_is_drawee: bool,
+    pub files: Vec<TempFile<'r>>,
 }
 
 #[derive(FromForm, Debug, Serialize, Deserialize)]

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -7,22 +7,22 @@ use crate::bill::contacts::get_current_payee_private_key;
 use crate::bill::get_path_for_bill;
 use crate::blockchain::{Chain, ChainToReturn, GossipsubEvent, GossipsubEventId, OperationCode};
 use crate::constants::IDENTITY_FILE_PATH;
-use crate::external;
 use crate::external::mint::{accept_mint_bitcredit, request_to_mint_bitcredit};
-use crate::service::contact_service::IdentityPublicData;
+use crate::service::{contact_service::IdentityPublicData, Result};
+use crate::util::file::detect_content_type_for_bytes;
 use crate::{
     bill::{
-        accept_bill, endorse_bitcredit_bill, get_bills_for_list,
+        endorse_bitcredit_bill, get_bills_for_list,
         identity::{get_whole_identity, read_peer_id_from_file, IdentityWithAll},
-        issue_new_bill, issue_new_bill_drawer_is_drawee, issue_new_bill_drawer_is_payee,
         mint_bitcredit_bill, read_bill_from_file, request_acceptance, request_pay,
         sell_bitcredit_bill, BitcreditBill, BitcreditBillToReturn,
     },
     service::ServiceContext,
 };
-use log::{info, warn};
+use crate::{external, service};
+use log::warn;
 use rocket::form::Form;
-use rocket::http::Status;
+use rocket::http::{ContentType, Status};
 use rocket::serde::json::Json;
 use rocket::{get, post, put, State};
 use std::path::Path;
@@ -34,6 +34,25 @@ pub async fn holder(id: String) -> Json<bool> {
     let bill: BitcreditBill = read_bill_from_file(&id).await;
     let am_i_holder = identity.peer_id.to_string().eq(&bill.payee.peer_id);
     Json(am_i_holder)
+}
+
+#[get("/attachment/<bill_name>/<file_name>")]
+pub async fn attachment(
+    state: &State<ServiceContext>,
+    bill_name: &str,
+    file_name: &str,
+) -> Result<(ContentType, Vec<u8>)> {
+    let keys = state.bill_service.get_bill_keys(bill_name).await?;
+    let file_bytes = state
+        .bill_service
+        .open_and_decrypt_attached_file(bill_name, file_name, &keys.private_key_pem)
+        .await?;
+
+    let content_type =
+        detect_content_type_for_bytes(&file_bytes).ok_or(service::Error::Validation(
+            String::from("Content Type of the requested file could not be determined"),
+        ))?;
+    Ok((content_type, file_bytes))
 }
 
 #[get("/return")]
@@ -208,137 +227,129 @@ pub async fn search_bill(state: &State<ServiceContext>) -> Status {
 #[post("/issue", data = "<bill_form>")]
 pub async fn issue_bill(
     state: &State<ServiceContext>,
-    bill_form: Form<BitcreditBillForm>,
-) -> Status {
+    bill_form: Form<BitcreditBillForm<'_>>,
+) -> Result<Status> {
     if !Path::new(IDENTITY_FILE_PATH).exists() {
-        Status::NotAcceptable
-    } else {
-        let mut status: Status = Status::Ok;
-
-        let form_bill = bill_form.into_inner();
-        let drawer = get_whole_identity();
-        let mut client = state.dht_client();
-        let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
-        let mut bill = BitcreditBill::new_empty();
-
-        if form_bill.drawer_is_payee {
-            let public_data_drawee = state
-                .contact_service
-                .get_identity_by_name(&form_bill.drawee_name)
-                .await
-                .expect("Can not get drawee identity.");
-
-            if !public_data_drawee.name.is_empty() {
-                bill = issue_new_bill_drawer_is_payee(
-                    form_bill.bill_jurisdiction,
-                    form_bill.place_of_drawing,
-                    form_bill.amount_numbers,
-                    form_bill.place_of_payment,
-                    form_bill.maturity_date,
-                    form_bill.currency_code,
-                    drawer.clone(),
-                    form_bill.language,
-                    public_data_drawee,
-                    timestamp,
-                );
-            } else {
-                status = Status::NotAcceptable
-            }
-        } else if form_bill.drawer_is_drawee {
-            let public_data_payee = state
-                .contact_service
-                .get_identity_by_name(&form_bill.payee_name)
-                .await
-                .expect("Can not get payee identity.");
-
-            if !public_data_payee.name.is_empty() {
-                bill = issue_new_bill_drawer_is_drawee(
-                    form_bill.bill_jurisdiction,
-                    form_bill.place_of_drawing,
-                    form_bill.amount_numbers,
-                    form_bill.place_of_payment,
-                    form_bill.maturity_date,
-                    form_bill.currency_code,
-                    drawer.clone(),
-                    form_bill.language,
-                    public_data_payee,
-                    timestamp,
-                );
-            } else {
-                status = Status::NotAcceptable
-            }
-        } else {
-            let public_data_drawee = state
-                .contact_service
-                .get_identity_by_name(&form_bill.drawee_name)
-                .await
-                .expect("Can not get drawee identity.");
-
-            let public_data_payee = state
-                .contact_service
-                .get_identity_by_name(&form_bill.payee_name)
-                .await
-                .expect("Can not get payee public data");
-
-            if !public_data_payee.name.is_empty() && !public_data_drawee.name.is_empty() {
-                bill = issue_new_bill(
-                    form_bill.bill_jurisdiction,
-                    form_bill.place_of_drawing,
-                    form_bill.amount_numbers,
-                    form_bill.place_of_payment,
-                    form_bill.maturity_date,
-                    form_bill.currency_code,
-                    drawer.clone(),
-                    form_bill.language,
-                    public_data_drawee,
-                    public_data_payee,
-                    timestamp,
-                );
-            } else {
-                status = Status::NotAcceptable
-            }
-        }
-
-        if status.eq(&Status::Ok) {
-            let mut nodes: Vec<String> = Vec::new();
-            let my_peer_id = drawer.peer_id.to_string().clone();
-            nodes.push(my_peer_id.to_string());
-            nodes.push(bill.drawee.peer_id.clone());
-            nodes.push(bill.payee.peer_id.clone());
-
-            for node in nodes {
-                if !node.is_empty() {
-                    info!("issue bill: add {} for node {}", &bill.name, &node);
-                    client.add_bill_to_dht_for_node(&bill.name, &node).await;
-                }
-            }
-
-            client.subscribe_to_topic(bill.name.clone()).await;
-
-            client.put(&bill.name).await;
-
-            if form_bill.drawer_is_drawee {
-                let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
-
-                let correct = accept_bill(&bill.name, timestamp).await;
-
-                if correct {
-                    let chain: Chain = Chain::read_chain_from_file(&bill.name);
-                    let block = chain.get_latest_block();
-
-                    let block_bytes = serde_json::to_vec(block).expect("Error serializing block");
-                    let event = GossipsubEvent::new(GossipsubEventId::Block, block_bytes);
-                    let message = event.to_byte_array();
-
-                    client
-                        .add_message_to_topic(message, bill.name.clone())
-                        .await;
-                }
-            }
-        }
-
-        status
+        return Err(service::Error::PreconditionFailed);
     }
+
+    // Validate Files
+    let files = &bill_form.files;
+    for file in files {
+        state.bill_service.validate_attached_file(file).await?;
+    }
+
+    let form_bill = bill_form.into_inner();
+    let drawer = get_whole_identity();
+
+    let (public_data_drawee, public_data_payee) =
+        match (form_bill.drawer_is_payee, form_bill.drawer_is_drawee) {
+            // Drawer is drawee and payee
+            (true, true) => {
+                return Err(service::Error::Validation(String::from(
+                    "Drawer can't be Drawee and Payee at the same time",
+                )));
+            }
+            // Drawer is payee
+            (true, false) => {
+                let public_data_drawee = state
+                    .contact_service
+                    .get_identity_by_name(&form_bill.drawee_name)
+                    .await
+                    .map_err(|_| {
+                        service::Error::Validation(String::from("Can not get drawee identity."))
+                    })?;
+
+                let public_data_payee =
+                    IdentityPublicData::new(drawer.identity.clone(), drawer.peer_id.to_string());
+
+                (public_data_drawee, public_data_payee)
+            }
+            // Drawer is drawee
+            (false, true) => {
+                let public_data_drawee =
+                    IdentityPublicData::new(drawer.identity.clone(), drawer.peer_id.to_string());
+
+                let public_data_payee = state
+                    .contact_service
+                    .get_identity_by_name(&form_bill.payee_name)
+                    .await
+                    .map_err(|_| {
+                        service::Error::Validation(String::from("Can not get payee identity."))
+                    })?;
+
+                (public_data_drawee, public_data_payee)
+            }
+            // Drawer is neither drawee nor payee
+            (false, false) => {
+                let public_data_drawee = state
+                    .contact_service
+                    .get_identity_by_name(&form_bill.drawee_name)
+                    .await
+                    .map_err(|_| {
+                        service::Error::Validation(String::from("Can not get drawee identity."))
+                    })?;
+
+                let public_data_payee = state
+                    .contact_service
+                    .get_identity_by_name(&form_bill.payee_name)
+                    .await
+                    .map_err(|_| {
+                        service::Error::Validation(String::from("Can not get payee identity."))
+                    })?;
+                (public_data_drawee, public_data_payee)
+            }
+        };
+
+    if public_data_drawee.name.is_empty() {
+        return Err(service::Error::Validation(String::from(
+            "Drawee not found.",
+        )));
+    }
+
+    if public_data_payee.name.is_empty() {
+        return Err(service::Error::Validation(String::from("Payee not found.")));
+    }
+
+    if public_data_drawee.name == public_data_payee.name {
+        return Err(service::Error::Validation(String::from(
+            "Drawee and payee can't be the same.",
+        )));
+    }
+
+    let bill = state
+        .bill_service
+        .issue_new_bill(
+            form_bill.bill_jurisdiction,
+            form_bill.place_of_drawing,
+            form_bill.amount_numbers,
+            form_bill.place_of_payment,
+            form_bill.maturity_date,
+            form_bill.currency_code,
+            drawer,
+            form_bill.language,
+            public_data_drawee,
+            public_data_payee,
+            &form_bill.files,
+        )
+        .await?;
+
+    state
+        .bill_service
+        .propagate_bill(
+            &bill.name,
+            &bill.drawer.peer_id,
+            &bill.drawee.peer_id,
+            &bill.payee.peer_id,
+        )
+        .await?;
+
+    // If we're the drawee, we immediately accept the bill
+    if bill.drawer == bill.drawee {
+        state.bill_service.accept_bill(&bill.name).await?;
+    }
+
+    Ok(Status::Ok)
 }
 
 #[put("/sell", data = "<sell_bill_form>")]
@@ -358,7 +369,10 @@ pub async fn sell_bill(
             .expect("Can not get buyer identity.");
 
         if !public_data_buyer.name.is_empty() {
-            let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+            let timestamp = external::time::TimeApi::get_atomic_time()
+                .await
+                .unwrap()
+                .timestamp;
 
             let correct = sell_bitcredit_bill(
                 &sell_bill_form.bill_name,
@@ -411,7 +425,10 @@ pub async fn endorse_bill(
             .expect("Can not get endorsee identity.");
 
         if !public_data_endorsee.name.is_empty() {
-            let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+            let timestamp = external::time::TimeApi::get_atomic_time()
+                .await
+                .unwrap()
+                .timestamp;
 
             let correct = endorse_bitcredit_bill(
                 &endorse_bill_form.bill_name,
@@ -457,7 +474,10 @@ pub async fn request_to_pay_bill(
     } else {
         let mut client = state.dht_client();
 
-        let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+        let timestamp = external::time::TimeApi::get_atomic_time()
+            .await
+            .unwrap()
+            .timestamp;
 
         let correct = request_pay(&request_to_pay_bill_form.bill_name, timestamp).await;
 
@@ -487,7 +507,10 @@ pub async fn request_to_accept_bill(
     } else {
         let mut client = state.dht_client();
 
-        let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+        let timestamp = external::time::TimeApi::get_atomic_time()
+            .await
+            .unwrap()
+            .timestamp;
 
         let correct = request_acceptance(&request_to_accept_bill_form.bill_name, timestamp).await;
 
@@ -511,30 +534,15 @@ pub async fn request_to_accept_bill(
 pub async fn accept_bill_form(
     state: &State<ServiceContext>,
     accept_bill_form: Form<AcceptBitcreditBillForm>,
-) -> Status {
+) -> Result<Status> {
     if !Path::new(IDENTITY_FILE_PATH).exists() {
-        Status::NotAcceptable
-    } else {
-        let mut client = state.dht_client();
-
-        let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
-
-        let correct = accept_bill(&accept_bill_form.bill_name, timestamp).await;
-
-        if correct {
-            let chain: Chain = Chain::read_chain_from_file(&accept_bill_form.bill_name);
-            let block = chain.get_latest_block();
-
-            let block_bytes = serde_json::to_vec(block).expect("Error serializing block");
-            let event = GossipsubEvent::new(GossipsubEventId::Block, block_bytes);
-            let message = event.to_byte_array();
-
-            client
-                .add_message_to_topic(message, accept_bill_form.bill_name.clone())
-                .await;
-        }
-        Status::Ok
+        return Err(service::Error::PreconditionFailed);
     }
+    state
+        .bill_service
+        .accept_bill(&accept_bill_form.bill_name)
+        .await?;
+    Ok(Status::Ok)
 }
 
 // Mint
@@ -632,7 +640,10 @@ pub async fn mint_bill(
     } else {
         let mut client = state.dht_client();
 
-        let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+        let timestamp = external::time::TimeApi::get_atomic_time()
+            .await
+            .unwrap()
+            .timestamp;
 
         let public_mint_node = state
             .contact_service

--- a/src/web/handlers/quotes.rs
+++ b/src/web/handlers/quotes.rs
@@ -34,7 +34,10 @@ pub async fn accept_quote(
         .await?;
 
     if !public_data_endorsee.name.is_empty() {
-        let timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+        let timestamp = external::time::TimeApi::get_atomic_time()
+            .await
+            .unwrap()
+            .timestamp;
         endorse_bitcredit_bill(&quote.bill_id, public_data_endorsee.clone(), timestamp).await;
     }
 


### PR DESCRIPTION
This fixes #115 and adds the functionality for uploading files when issueing a bill, as well as to locally view these uploaded files.

Notes
* This changes the `bill` file format, so any previously saved bill will be invalid from merging this onward and will likely panic the app
* There is an issue when trying to send files, which are above a certain size (~50kb, which is around ~200kb doubly encrypted) between p2p clients using libp2p. I created an extra task for it (https://github.com/BitcreditProtocol/E-Bill/issues/218), which we might not do, since it might be a time sink and moving to Nostr fixes the issue anyway.

Besides that, I restructured a few things and added tests where possible and transitioned the contacts API to use `tokio::fs`, as to not block on the async runtime.