### PR TITLE
139 company identity setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /quotes/*
 /test/*
 /files/*
+/company/*

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -21,7 +21,6 @@ use log::error;
 use log::warn;
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
-use rocket::FromForm;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -30,7 +29,7 @@ pub struct Chain {
     pub blocks: Vec<Block>,
 }
 
-#[derive(BorshSerialize, BorshDeserialize, FromForm, Debug, Serialize, Deserialize, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
 pub struct BlockForHistory {
     id: u64,
     text: String,

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -3,7 +3,6 @@ use borsh_derive::{BorshDeserialize, BorshSerialize};
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
 use openssl::sha::Sha256;
-use rocket::FromFormField;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -59,7 +58,7 @@ impl ChainToReturn {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, FromFormField)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum OperationCode {
     Issue,
     Accept,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -9,7 +9,7 @@ pub const KEY_PREFIX: &str = "KEY";
 pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1500;
 
 // Validation
-pub const MAX_FILE_SIZE_BYTES: usize = 5_000_000; // ~5 MB
+pub const MAX_FILE_SIZE_BYTES: usize = 1_000_000; // ~1 MB
 pub const MAX_FILE_NAME_CHARACTERS: usize = 50;
 pub const VALID_FILE_MIME_TYPES: [&str; 3] = ["image/jpeg", "image/png", "application/pdf"];
 

--- a/src/external/mint.rs
+++ b/src/external/mint.rs
@@ -17,7 +17,7 @@ use crate::{
         },
         read_keys_from_bill_file,
     },
-    web::RequestToMintBitcreditBillPayload,
+    web::data::RequestToMintBitcreditBillPayload,
 };
 
 // Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but

--- a/src/persistence/bill.rs
+++ b/src/persistence/bill.rs
@@ -7,7 +7,7 @@ use crate::{
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
 use tokio::{
-    fs::{create_dir_all, read, read_dir, remove_dir_all, write, File},
+    fs::{create_dir_all, read, read_dir, write, File},
     io::AsyncReadExt,
     task,
 };
@@ -67,31 +67,12 @@ pub trait BillStoreApi: Send + Sync {
 
     /// Reads bill keys from file
     async fn read_bill_keys_from_file(&self, bill_name: &str) -> Result<BillKeys>;
-
-    /// Creates temporary upload folder with the given name
-    async fn create_temp_upload_folder(&self, file_upload_id: &str) -> Result<()>;
-
-    /// Deletes temporary upload folder with the given name
-    async fn remove_temp_upload_folder(&self, file_upload_id: &str) -> Result<()>;
-
-    /// Writes the temporary upload file with the given file name and bytes for the given file_upload_id
-    async fn write_temp_upload_file(
-        &self,
-        file_upload_id: &str,
-        file_name: &str,
-        file_bytes: &[u8],
-    ) -> Result<()>;
-
-    /// Reads the temporary files from the given file_upload_id and returns their file name and
-    /// bytes
-    async fn read_temp_upload_files(&self, file_upload_id: &str) -> Result<Vec<(String, Vec<u8>)>>;
 }
 
 #[derive(Clone)]
 pub struct FileBasedBillStore {
     folder: String,
     files_folder: String,
-    temp_upload_folder: String,
     keys_folder: String,
 }
 
@@ -100,34 +81,16 @@ impl FileBasedBillStore {
         data_dir: &str,
         path: &str,
         files_path: &str,
-        temp_upload_path: &str,
         keys_path: &str,
     ) -> Result<Self> {
         let folder = file_storage_path(data_dir, path).await?;
         let files_folder = file_storage_path(&format!("{data_dir}/{files_path}"), path).await?;
-        let temp_upload_folder =
-            file_storage_path(&format!("{data_dir}/{files_path}/{path}"), temp_upload_path).await?;
         let keys_folder = file_storage_path(data_dir, keys_path).await?;
         Ok(Self {
             folder,
             files_folder,
-            temp_upload_folder,
             keys_folder,
         })
-    }
-
-    pub async fn cleanup_temp_uploads(&self) -> Result<()> {
-        log::info!("cleaning up temp upload folder for bills");
-        let path = Path::new(&self.temp_upload_folder);
-        let mut dir = read_dir(path).await?;
-        while let Some(entry) = dir.next_entry().await? {
-            let path = entry.path();
-            if path.is_dir() {
-                log::info!("deleting temp upload folder for bill at {path:?}");
-                remove_dir_all(path).await?;
-            }
-        }
-        Ok(())
     }
 
     pub fn get_path_for_bills(&self) -> PathBuf {
@@ -265,53 +228,5 @@ impl BillStoreApi for FileBasedBillStore {
         let input_path = self.get_path_for_bill_keys(bill_name);
         let bytes = read(&input_path).await?;
         serde_json::from_slice(&bytes).map_err(super::Error::Json)
-    }
-
-    async fn create_temp_upload_folder(&self, file_upload_id: &str) -> Result<()> {
-        let dest_dir = Path::new(&self.temp_upload_folder).join(file_upload_id);
-        if !dest_dir.exists() {
-            create_dir_all(&dest_dir).await?;
-        }
-        Ok(())
-    }
-
-    async fn remove_temp_upload_folder(&self, file_upload_id: &str) -> Result<()> {
-        let dest_dir = Path::new(&self.temp_upload_folder).join(file_upload_id);
-        if dest_dir.exists() {
-            log::info!("deleting temp upload folder for bill at {dest_dir:?}");
-            remove_dir_all(dest_dir).await?;
-        }
-        Ok(())
-    }
-
-    async fn write_temp_upload_file(
-        &self,
-        file_upload_id: &str,
-        file_name: &str,
-        file_bytes: &[u8],
-    ) -> Result<()> {
-        let dest = Path::new(&self.temp_upload_folder)
-            .join(file_upload_id)
-            .join(file_name);
-        write(dest, file_bytes).await?;
-        Ok(())
-    }
-
-    async fn read_temp_upload_files(&self, file_upload_id: &str) -> Result<Vec<(String, Vec<u8>)>> {
-        let mut files = Vec::new();
-        let folder = Path::new(&self.temp_upload_folder).join(file_upload_id);
-        let mut dir = read_dir(&folder).await?;
-        while let Some(entry) = dir.next_entry().await? {
-            if is_not_hidden_or_directory_async(&entry).await {
-                let file_path = entry.path();
-                if let Some(file_name) = file_path.file_name() {
-                    if let Some(file_name_str) = file_name.to_str() {
-                        let file_bytes = read(&file_path).await?;
-                        files.push((file_name_str.to_owned(), file_bytes));
-                    }
-                }
-            }
-        }
-        Ok(files)
     }
 }

--- a/src/persistence/bill.rs
+++ b/src/persistence/bill.rs
@@ -177,11 +177,11 @@ impl BillStoreApi for FileBasedBillStore {
     }
 
     async fn open_attached_file(&self, bill_name: &str, file_name: &str) -> Result<Vec<u8>> {
-        let folder = Path::new(&self.files_folder)
+        let path = Path::new(&self.files_folder)
             .join(bill_name)
             .join(file_name);
 
-        let mut file = File::open(&folder).await?;
+        let mut file = File::open(&path).await?;
         let mut buf = Vec::new();
 
         file.read_to_end(&mut buf).await?;

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -7,9 +7,10 @@ use std::{
 use super::{file_storage_path, Result};
 use async_trait::async_trait;
 use futures::future::try_join_all;
-use log::error;
+use log::{error, info};
 use tokio::{
-    fs::{create_dir_all, read, read_dir, write},
+    fs::{create_dir_all, read, read_dir, remove_dir_all, write, File},
+    io::AsyncReadExt,
     task,
 };
 
@@ -17,18 +18,38 @@ use tokio::{
 pub trait CompanyStoreApi: Send + Sync {
     /// Checks if the given company exists
     async fn exists(&self, id: &str) -> bool;
+
     /// Fetches the given company
     async fn get(&self, id: &str) -> Result<Company>;
+
     /// Returns all companies
-    async fn get_all(&self) -> Result<HashMap<String, Company>>;
+    async fn get_all(&self) -> Result<HashMap<String, (Company, CompanyKeys)>>;
+
     /// Inserts the company with the given id
     async fn insert(&self, id: &str, data: &Company) -> Result<()>;
+
     /// Updates the company with the given id
     async fn update(&self, id: &str, data: &Company) -> Result<()>;
+
+    /// Removes the company with the given id (e.g. if we're removed as signatory)
+    async fn remove(&self, id: &str) -> Result<()>;
+
     /// Saves the key pair for the given company id
     async fn save_key_pair(&self, id: &str, key_pair: &CompanyKeys) -> Result<()>;
+
     /// Gets the key pair for the given company id
     async fn get_key_pair(&self, id: &str) -> Result<CompanyKeys>;
+
+    /// Writes the given encrypted bytes of an attached file to disk
+    async fn save_attached_file(
+        &self,
+        encrypted_bytes: &[u8],
+        id: &str,
+        file_name: &str,
+    ) -> Result<()>;
+
+    /// Opens the given attached file from disk
+    async fn open_attached_file(&self, id: &str, file_name: &str) -> Result<Vec<u8>>;
 }
 
 #[derive(Clone)]
@@ -86,7 +107,7 @@ impl CompanyStoreApi for FileBasedCompanyStore {
         Ok(company)
     }
 
-    async fn get_all(&self) -> Result<HashMap<String, Company>> {
+    async fn get_all(&self) -> Result<HashMap<String, (Company, CompanyKeys)>> {
         let folder_path = Path::new(&self.folder);
 
         let mut dir = read_dir(&folder_path).await?;
@@ -101,11 +122,12 @@ impl CompanyStoreApi for FileBasedCompanyStore {
         }
 
         let tasks = ids.into_iter().map(|id| async move {
-            let result = self.get(&id).await?;
-            Ok((id, result)) as Result<(String, Company)>
+            let company = self.get(&id).await?;
+            let keys = self.get_key_pair(&id).await?;
+            Ok((id, (company, keys))) as Result<(String, (Company, CompanyKeys))>
         });
         let results = try_join_all(tasks).await?;
-        let map: HashMap<String, Company> = results.into_iter().collect();
+        let map: HashMap<String, (Company, CompanyKeys)> = results.into_iter().collect();
         Ok(map)
     }
 
@@ -137,7 +159,25 @@ impl CompanyStoreApi for FileBasedCompanyStore {
         Ok(())
     }
 
+    async fn remove(&self, id: &str) -> Result<()> {
+        let folder_path = self.get_path_for_company_id(id);
+        if !folder_path.exists() {
+            error!("could not find company folder for {id} to update company");
+            return Err(super::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "company folder not found",
+            )));
+        }
+        info!("removing folder and all files for company {id}");
+        remove_dir_all(folder_path).await?;
+        Ok(())
+    }
+
     async fn save_key_pair(&self, id: &str, key_pair: &CompanyKeys) -> Result<()> {
+        let folder_path = self.get_path_for_company_id(id);
+        if !folder_path.exists() {
+            create_dir_all(&folder_path).await?;
+        }
         let path = self.get_path_for_company_key_pair(id);
         let json = serde_json::to_string_pretty(key_pair)?;
         write(path, &json).await?;
@@ -149,5 +189,30 @@ impl CompanyStoreApi for FileBasedCompanyStore {
         let bytes = read(&path).await?;
         let keys = serde_json::from_slice(&bytes)?;
         Ok(keys)
+    }
+
+    async fn save_attached_file(
+        &self,
+        encrypted_bytes: &[u8],
+        id: &str,
+        file_name: &str,
+    ) -> Result<()> {
+        let dest_dir = self.get_path_for_company_id(id);
+        if !dest_dir.exists() {
+            create_dir_all(&dest_dir).await?;
+        }
+        let dest_file = dest_dir.join(file_name);
+        write(dest_file, encrypted_bytes).await?;
+        Ok(())
+    }
+
+    async fn open_attached_file(&self, id: &str, file_name: &str) -> Result<Vec<u8>> {
+        let path = self.get_path_for_company_id(id).join(file_name);
+
+        let mut file = File::open(&path).await?;
+        let mut buf = Vec::new();
+
+        file.read_to_end(&mut buf).await?;
+        Ok(buf)
     }
 }

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -1,0 +1,153 @@
+use crate::service::company_service::{Company, CompanyKeys};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use super::{file_storage_path, Result};
+use async_trait::async_trait;
+use futures::future::try_join_all;
+use log::error;
+use tokio::{
+    fs::{create_dir_all, read, read_dir, write},
+    task,
+};
+
+#[async_trait]
+pub trait CompanyStoreApi: Send + Sync {
+    /// Checks if the given company exists
+    async fn exists(&self, id: &str) -> bool;
+    /// Fetches the given company
+    async fn get(&self, id: &str) -> Result<Company>;
+    /// Returns all companies
+    async fn get_all(&self) -> Result<HashMap<String, Company>>;
+    /// Inserts the company with the given id
+    async fn insert(&self, id: &str, data: &Company) -> Result<()>;
+    /// Updates the company with the given id
+    async fn update(&self, id: &str, data: &Company) -> Result<()>;
+    /// Saves the key pair for the given company id
+    async fn save_key_pair(&self, id: &str, key_pair: &CompanyKeys) -> Result<()>;
+    /// Gets the key pair for the given company id
+    async fn get_key_pair(&self, id: &str) -> Result<CompanyKeys>;
+}
+
+#[derive(Clone)]
+pub struct FileBasedCompanyStore {
+    folder: String,
+    data_file: String,
+    key_pair_file: String,
+}
+
+impl FileBasedCompanyStore {
+    pub async fn new(
+        data_dir: &str,
+        path: &str,
+        data_file: &str,
+        key_pair_file: &str,
+    ) -> Result<Self> {
+        let folder = file_storage_path(data_dir, path).await?;
+        Ok(Self {
+            folder,
+            data_file: data_file.to_owned(),
+            key_pair_file: key_pair_file.to_owned(),
+        })
+    }
+
+    pub fn get_path_for_company_id(&self, id: &str) -> PathBuf {
+        PathBuf::from(self.folder.as_str()).join(id)
+    }
+
+    pub fn get_path_for_company_data(&self, id: &str) -> PathBuf {
+        PathBuf::from(self.folder.as_str())
+            .join(id)
+            .join(&self.data_file)
+    }
+
+    pub fn get_path_for_company_key_pair(&self, id: &str) -> PathBuf {
+        PathBuf::from(self.folder.as_str())
+            .join(id)
+            .join(&self.key_pair_file)
+    }
+}
+
+#[async_trait]
+impl CompanyStoreApi for FileBasedCompanyStore {
+    async fn exists(&self, id: &str) -> bool {
+        let path = self.get_path_for_company_data(id);
+        task::spawn_blocking(move || path.exists())
+            .await
+            .unwrap_or(false)
+    }
+
+    async fn get(&self, id: &str) -> Result<Company> {
+        let path = self.get_path_for_company_data(id);
+        let bytes = read(path).await?;
+        let company: Company = serde_json::from_slice(&bytes)?;
+        Ok(company)
+    }
+
+    async fn get_all(&self) -> Result<HashMap<String, Company>> {
+        let folder_path = Path::new(&self.folder);
+
+        let mut dir = read_dir(&folder_path).await?;
+        let mut ids = vec![];
+        while let Some(entry) = dir.next_entry().await? {
+            let metadata = entry.metadata().await?;
+            if metadata.is_dir() {
+                if let Some(dir_name) = entry.file_name().to_str() {
+                    ids.push(dir_name.to_owned());
+                }
+            }
+        }
+
+        let tasks = ids.into_iter().map(|id| async move {
+            let result = self.get(&id).await?;
+            Ok((id, result)) as Result<(String, Company)>
+        });
+        let results = try_join_all(tasks).await?;
+        let map: HashMap<String, Company> = results.into_iter().collect();
+        Ok(map)
+    }
+
+    async fn insert(&self, id: &str, data: &Company) -> Result<()> {
+        let folder_path = self.get_path_for_company_id(id);
+        if !folder_path.exists() {
+            create_dir_all(&folder_path).await?;
+        }
+
+        let json = serde_json::to_string_pretty(data)?;
+        let path = self.get_path_for_company_data(id);
+        write(path, &json).await?;
+        Ok(())
+    }
+
+    async fn update(&self, id: &str, data: &Company) -> Result<()> {
+        let folder_path = self.get_path_for_company_id(id);
+        if !folder_path.exists() {
+            error!("could not find company folder for {id} to update company");
+            return Err(super::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "company folder not found",
+            )));
+        }
+
+        let json = serde_json::to_string_pretty(data)?;
+        let path = self.get_path_for_company_data(id);
+        write(path, &json).await?;
+        Ok(())
+    }
+
+    async fn save_key_pair(&self, id: &str, key_pair: &CompanyKeys) -> Result<()> {
+        let path = self.get_path_for_company_key_pair(id);
+        let json = serde_json::to_string_pretty(key_pair)?;
+        write(path, &json).await?;
+        Ok(())
+    }
+
+    async fn get_key_pair(&self, id: &str) -> Result<CompanyKeys> {
+        let path = self.get_path_for_company_key_pair(id);
+        let bytes = read(&path).await?;
+        let keys = serde_json::from_slice(&bytes)?;
+        Ok(keys)
+    }
+}

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -14,6 +14,10 @@ use tokio::{
     task,
 };
 
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait CompanyStoreApi: Send + Sync {
     /// Checks if the given company exists

--- a/src/persistence/contact.rs
+++ b/src/persistence/contact.rs
@@ -5,6 +5,10 @@ use std::{collections::HashMap, fs, path::Path};
 use super::{file_storage_path, Error, Result};
 use async_trait::async_trait;
 
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait ContactStoreApi: Send + Sync {
     async fn get_map(&self) -> Result<HashMap<String, IdentityPublicData>>;

--- a/src/persistence/file_upload.rs
+++ b/src/persistence/file_upload.rs
@@ -1,0 +1,108 @@
+use super::{file_storage_path, Result};
+use crate::util::file::is_not_hidden_or_directory_async;
+use async_trait::async_trait;
+use std::path::Path;
+use tokio::fs::{create_dir_all, read, read_dir, remove_dir_all, write};
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait FileUploadStoreApi: Send + Sync {
+    /// Creates temporary upload folder with the given name
+    async fn create_temp_upload_folder(&self, file_upload_id: &str) -> Result<()>;
+
+    /// Deletes temporary upload folder with the given name
+    async fn remove_temp_upload_folder(&self, file_upload_id: &str) -> Result<()>;
+
+    /// Writes the temporary upload file with the given file name and bytes for the given file_upload_id
+    async fn write_temp_upload_file(
+        &self,
+        file_upload_id: &str,
+        file_name: &str,
+        file_bytes: &[u8],
+    ) -> Result<()>;
+
+    /// Reads the temporary files from the given file_upload_id and returns their file name and
+    /// bytes
+    async fn read_temp_upload_files(&self, file_upload_id: &str) -> Result<Vec<(String, Vec<u8>)>>;
+}
+
+#[derive(Clone)]
+pub struct FileUploadStore {
+    temp_upload_folder: String,
+}
+
+impl FileUploadStore {
+    pub async fn new(data_dir: &str, files_path: &str, temp_upload_path: &str) -> Result<Self> {
+        let temp_upload_folder =
+            file_storage_path(&format!("{data_dir}/{files_path}"), temp_upload_path).await?;
+        Ok(Self { temp_upload_folder })
+    }
+
+    pub async fn cleanup_temp_uploads(&self) -> Result<()> {
+        log::info!("cleaning up temp upload folder");
+        let path = Path::new(&self.temp_upload_folder);
+        let mut dir = read_dir(path).await?;
+        while let Some(entry) = dir.next_entry().await? {
+            let path = entry.path();
+            if path.is_dir() {
+                log::info!("deleting temp upload folder at {path:?}");
+                remove_dir_all(path).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl FileUploadStoreApi for FileUploadStore {
+    async fn create_temp_upload_folder(&self, file_upload_id: &str) -> Result<()> {
+        let dest_dir = Path::new(&self.temp_upload_folder).join(file_upload_id);
+        if !dest_dir.exists() {
+            create_dir_all(&dest_dir).await?;
+        }
+        Ok(())
+    }
+
+    async fn remove_temp_upload_folder(&self, file_upload_id: &str) -> Result<()> {
+        let dest_dir = Path::new(&self.temp_upload_folder).join(file_upload_id);
+        if dest_dir.exists() {
+            log::info!("deleting temp upload folder for bill at {dest_dir:?}");
+            remove_dir_all(dest_dir).await?;
+        }
+        Ok(())
+    }
+
+    async fn write_temp_upload_file(
+        &self,
+        file_upload_id: &str,
+        file_name: &str,
+        file_bytes: &[u8],
+    ) -> Result<()> {
+        let dest = Path::new(&self.temp_upload_folder)
+            .join(file_upload_id)
+            .join(file_name);
+        write(dest, file_bytes).await?;
+        Ok(())
+    }
+
+    async fn read_temp_upload_files(&self, file_upload_id: &str) -> Result<Vec<(String, Vec<u8>)>> {
+        let mut files = Vec::new();
+        let folder = Path::new(&self.temp_upload_folder).join(file_upload_id);
+        let mut dir = read_dir(&folder).await?;
+        while let Some(entry) = dir.next_entry().await? {
+            if is_not_hidden_or_directory_async(&entry).await {
+                let file_path = entry.path();
+                if let Some(file_name) = file_path.file_name() {
+                    if let Some(file_name_str) = file_name.to_str() {
+                        let file_bytes = read(&file_path).await?;
+                        files.push((file_name_str.to_owned(), file_bytes));
+                    }
+                }
+            }
+        }
+        Ok(files)
+    }
+}

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -2,6 +2,7 @@ pub mod bill;
 pub mod company;
 pub mod contact;
 pub mod db;
+pub mod file_upload;
 pub mod identity;
 
 use bill::FileBasedBillStore;

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -40,6 +40,8 @@ pub enum Error {
 pub use contact::ContactStoreApi;
 
 use crate::config::Config;
+use company::FileBasedCompanyStore;
+use file_upload::FileUploadStore;
 
 /// Given a base path and a directory path, ensures that the directory
 /// exists and returns the full path.
@@ -57,6 +59,8 @@ pub struct DbContext {
     pub contact_store: Arc<dyn ContactStoreApi>,
     pub bill_store: Arc<dyn bill::BillStoreApi>,
     pub identity_store: Arc<dyn identity::IdentityStoreApi>,
+    pub company_store: Arc<dyn company::CompanyStoreApi>,
+    pub file_upload_store: Arc<dyn file_upload::FileUploadStoreApi>,
 }
 
 /// Creates a new instance of the DbContext with the given SurrealDB configuration.
@@ -64,21 +68,19 @@ pub async fn get_db_context(conf: &Config) -> Result<DbContext> {
     let surreal_db_config = SurrealDbConfig::new(&conf.surreal_db_connection);
     let db = get_surreal_db(&surreal_db_config).await?;
 
-    let contact_store = Arc::new(SurrealContactStore::new(db));
+    let company_store =
+        Arc::new(FileBasedCompanyStore::new(&conf.data_dir, "company", "data", "keys").await?);
+    let file_upload_store =
+        Arc::new(FileUploadStore::new(&conf.data_dir, "files", "temp_upload").await?);
 
-    let bill_store = Arc::new(
-        FileBasedBillStore::new(
-            &conf.data_dir,
-            "bills",
-            "files",
-            "temp_upload",
-            "bills_keys",
-        )
-        .await?,
-    );
-    if let Err(e) = bill_store.cleanup_temp_uploads().await {
+    if let Err(e) = file_upload_store.cleanup_temp_uploads().await {
         error!("Error cleaning up temp upload folder for bill: {e}");
     }
+
+    let contact_store = Arc::new(SurrealContactStore::new(db));
+
+    let bill_store =
+        Arc::new(FileBasedBillStore::new(&conf.data_dir, "bills", "files", "bills_keys").await?);
 
     let identity_store = Arc::new(
         FileBasedIdentityStore::new(
@@ -95,5 +97,7 @@ pub async fn get_db_context(conf: &Config) -> Result<DbContext> {
         contact_store,
         bill_store,
         identity_store,
+        company_store,
+        file_upload_store,
     })
 }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,4 +1,5 @@
 pub mod bill;
+pub mod company;
 pub mod contact;
 pub mod db;
 pub mod identity;

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -571,13 +571,7 @@ impl BillServiceApi for BillService {
         file_upload_id: Option<String>,
         timestamp: i64,
     ) -> Result<BitcreditBill> {
-        let s = bitcoin::secp256k1::Secp256k1::new();
-        let private_key = bitcoin::PrivateKey::new(
-            s.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
-                .0,
-            USEDNET,
-        );
-        let public_key = private_key.public_key(&s);
+        let (private_key, public_key) = util::create_bitcoin_keypair(USEDNET);
 
         let bill_name = util::sha256_hash(&public_key.to_bytes());
 

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -1,4 +1,4 @@
-use crate::web::data::File;
+use crate::{persistence::file_upload::FileUploadStoreApi, web::data::File};
 use borsh_derive::{self, BorshDeserialize, BorshSerialize};
 use std::sync::Arc;
 
@@ -16,11 +16,18 @@ pub trait CompanyServiceApi: Send + Sync {}
 #[derive(Clone)]
 pub struct CompanyService {
     store: Arc<dyn CompanyStoreApi>,
+    file_upload_store: Arc<dyn FileUploadStoreApi>,
 }
 
 impl CompanyService {
-    pub fn new(store: Arc<dyn CompanyStoreApi>) -> Self {
-        Self { store }
+    pub fn new(
+        store: Arc<dyn CompanyStoreApi>,
+        file_upload_store: Arc<dyn FileUploadStoreApi>,
+    ) -> Self {
+        Self {
+            store,
+            file_upload_store,
+        }
     }
 }
 

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -1,4 +1,10 @@
-use crate::{persistence::file_upload::FileUploadStoreApi, web::data::File};
+use crate::{
+    constants::USEDNET,
+    error,
+    persistence::{file_upload::FileUploadStoreApi, identity::IdentityStoreApi, ContactStoreApi},
+    util,
+    web::data::File,
+};
 use borsh_derive::{self, BorshDeserialize, BorshSerialize};
 use std::sync::Arc;
 
@@ -8,31 +14,357 @@ use serde::{Deserialize, Serialize};
 use crate::persistence::company::CompanyStoreApi;
 
 use super::Result;
+use log::info;
 
 #[async_trait]
-pub trait CompanyServiceApi: Send + Sync {}
+pub trait CompanyServiceApi: Send + Sync {
+    /// Get a list of companies
+    async fn get_list_of_companies(&self) -> Result<Vec<CompanyToReturn>>;
+
+    /// Get a company by id
+    async fn get_company_by_id(&self, id: &str) -> Result<CompanyToReturn>;
+
+    /// Create a new company
+    async fn create_company(
+        &self,
+        legal_name: String,
+        country_of_registration: String,
+        city_of_registration: String,
+        postal_address: String,
+        legal_email: String,
+        registration_number: String,
+        registration_date: String,
+        proof_of_registration_file_upload_id: Option<String>,
+        logo_file_upload_id: Option<String>,
+    ) -> Result<CompanyToReturn>;
+
+    /// Changes the given company fields for the given company, if they are set
+    async fn edit_company(
+        &self,
+        id: &str,
+        legal_name: Option<String>,
+        legal_email: Option<String>,
+        postal_address: Option<String>,
+        logo_file_upload_id: Option<String>,
+    ) -> Result<()>;
+
+    /// Adds another signatory to the given company
+    async fn add_signatory(&self, id: &str, signatory_node_id: String) -> Result<()>;
+
+    /// Removes a signatory from the given company
+    async fn remove_signatory(&self, id: &str, signatory_node_id: String) -> Result<()>;
+
+    /// Encrypts and saves the given uploaded file, returning the file name, as well as the hash of
+    /// the unencrypted file
+    async fn encrypt_and_save_uploaded_file(
+        &self,
+        file_name: &str,
+        file_bytes: &[u8],
+        id: &str,
+        public_key: &str,
+    ) -> Result<File>;
+
+    /// opens and decrypts the attached file from the given company
+    async fn open_and_decrypt_file(
+        &self,
+        id: &str,
+        file_name: &str,
+        private_key: &str,
+    ) -> Result<Vec<u8>>;
+}
 
 /// The company service is responsible for managing the companies
 #[derive(Clone)]
 pub struct CompanyService {
     store: Arc<dyn CompanyStoreApi>,
     file_upload_store: Arc<dyn FileUploadStoreApi>,
+    identity_store: Arc<dyn IdentityStoreApi>,
+    contact_store: Arc<dyn ContactStoreApi>,
 }
 
 impl CompanyService {
     pub fn new(
         store: Arc<dyn CompanyStoreApi>,
         file_upload_store: Arc<dyn FileUploadStoreApi>,
+        identity_store: Arc<dyn IdentityStoreApi>,
+        contact_store: Arc<dyn ContactStoreApi>,
     ) -> Self {
         Self {
             store,
             file_upload_store,
+            identity_store,
+            contact_store,
         }
+    }
+
+    async fn process_upload_file(
+        &self,
+        upload_id: &Option<String>,
+        id: &str,
+        public_key: &str,
+    ) -> Result<Option<File>> {
+        if let Some(upload_id) = upload_id {
+            let files = self
+                .file_upload_store
+                .read_temp_upload_files(upload_id)
+                .await?;
+            if !files.is_empty() {
+                let (file_name, file_bytes) = &files[0];
+                let file = self
+                    .encrypt_and_save_uploaded_file(file_name, file_bytes, id, public_key)
+                    .await?;
+                return Ok(Some(file));
+            }
+        }
+        Ok(None)
     }
 }
 
 #[async_trait]
-impl CompanyServiceApi for CompanyService {}
+impl CompanyServiceApi for CompanyService {
+    async fn get_list_of_companies(&self) -> Result<Vec<CompanyToReturn>> {
+        let results = self.store.get_all().await?;
+        let companies: Vec<CompanyToReturn> = results
+            .into_iter()
+            .map(|(id, (company, keys))| CompanyToReturn::from(id, company, keys))
+            .collect();
+        Ok(companies)
+    }
+
+    async fn get_company_by_id(&self, id: &str) -> Result<CompanyToReturn> {
+        let company = self.store.get(id).await?;
+        let keys = self.store.get_key_pair(id).await?;
+        Ok(CompanyToReturn::from(id.to_owned(), company, keys))
+    }
+
+    async fn create_company(
+        &self,
+        legal_name: String,
+        country_of_registration: String,
+        city_of_registration: String,
+        postal_address: String,
+        legal_email: String,
+        registration_number: String,
+        registration_date: String,
+        proof_of_registration_file_upload_id: Option<String>,
+        logo_file_upload_id: Option<String>,
+    ) -> Result<CompanyToReturn> {
+        let (private_key, public_key) = util::create_bitcoin_keypair(USEDNET);
+        let id = util::sha256_hash(&public_key.to_bytes());
+
+        let company_keys = CompanyKeys {
+            private_key: private_key.to_string(),
+            public_key: public_key.to_string(),
+        };
+
+        let identity = self.identity_store.get().await?;
+        let peer_id = self.identity_store.get_peer_id().await?;
+
+        let proof_of_registration_file = self
+            .process_upload_file(
+                &proof_of_registration_file_upload_id,
+                &id,
+                &identity.public_key_pem,
+            )
+            .await?;
+
+        let logo_file = self
+            .process_upload_file(&logo_file_upload_id, &id, &identity.public_key_pem)
+            .await?;
+
+        self.store.save_key_pair(&id, &company_keys).await?;
+        let company = Company {
+            legal_name,
+            country_of_registration,
+            city_of_registration,
+            postal_address,
+            legal_email,
+            registration_number,
+            registration_date,
+            proof_of_registration_file,
+            logo_file,
+            signatories: vec![peer_id.to_string()], // add caller as signatory
+        };
+        self.store.insert(&id, &company).await?;
+
+        // clean up temporary file uploads, if there are any, logging any errors
+        for upload_id in [proof_of_registration_file_upload_id, logo_file_upload_id]
+            .iter()
+            .flatten()
+        {
+            if let Err(e) = self
+                .file_upload_store
+                .remove_temp_upload_folder(upload_id)
+                .await
+            {
+                error!("Error while cleaning up temporary file uploads for {upload_id}: {e}");
+            }
+        }
+
+        Ok(CompanyToReturn::from(id, company, company_keys))
+    }
+
+    async fn edit_company(
+        &self,
+        id: &str,
+        legal_name: Option<String>,
+        legal_email: Option<String>,
+        postal_address: Option<String>,
+        logo_file_upload_id: Option<String>,
+    ) -> Result<()> {
+        if !self.store.exists(id).await {
+            return Err(super::Error::Validation(String::from(
+                "No company with id: {id} found",
+            )));
+        }
+        let mut company = self.store.get(id).await?;
+        if let Some(legal_name_to_set) = legal_name {
+            company.legal_name = legal_name_to_set;
+        }
+        if let Some(legal_email_to_set) = legal_email {
+            company.legal_email = legal_email_to_set;
+        }
+        if let Some(postal_address_to_set) = postal_address {
+            company.postal_address = postal_address_to_set;
+        }
+        let identity = self.identity_store.get().await?;
+        let logo_file = self
+            .process_upload_file(&logo_file_upload_id, id, &identity.public_key_pem)
+            .await?;
+        company.logo_file = logo_file;
+
+        self.store.update(id, &company).await?;
+
+        Ok(())
+    }
+
+    async fn add_signatory(&self, id: &str, signatory_node_id: String) -> Result<()> {
+        if !self.store.exists(id).await {
+            return Err(super::Error::Validation(String::from(
+                "No company with id: {id} found.",
+            )));
+        }
+        let contacts = self.contact_store.get_map().await?;
+        let is_in_contacts = contacts
+            .iter()
+            .any(|(_name, identity)| identity.peer_id == signatory_node_id);
+        if !is_in_contacts {
+            return Err(super::Error::Validation(String::from(
+                "Node Id {signatory_node_id} is not in the contacts.",
+            )));
+        }
+
+        let mut company = self.store.get(id).await?;
+        if company.signatories.contains(&signatory_node_id) {
+            return Err(super::Error::Validation(String::from(
+                "Node Id {signatory_node_id} is already a signatory.",
+            )));
+        }
+        company.signatories.push(signatory_node_id);
+        self.store.update(id, &company).await?;
+
+        Ok(())
+    }
+
+    async fn remove_signatory(&self, id: &str, signatory_node_id: String) -> Result<()> {
+        if !self.store.exists(id).await {
+            return Err(super::Error::Validation(String::from(
+                "No company with id: {id} found.",
+            )));
+        }
+
+        let mut company = self.store.get(id).await?;
+        if company.signatories.len() == 1 {
+            return Err(super::Error::Validation(String::from(
+                "Can't remove last signatory.",
+            )));
+        }
+        if !company.signatories.contains(&signatory_node_id) {
+            return Err(super::Error::Validation(String::from(
+                "Node id {signatory_node_id} is not a signatory.",
+            )));
+        }
+
+        let peer_id = self.identity_store.get_peer_id().await?;
+
+        company.signatories.retain(|i| i != &signatory_node_id);
+        self.store.update(id, &company).await?;
+
+        if peer_id.to_string() == signatory_node_id {
+            info!("Removing self from company {id}");
+            self.store.remove(id).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn encrypt_and_save_uploaded_file(
+        &self,
+        file_name: &str,
+        file_bytes: &[u8],
+        id: &str,
+        public_key: &str,
+    ) -> Result<File> {
+        let file_hash = util::sha256_hash(file_bytes);
+        let encrypted = util::rsa::encrypt_bytes_with_public_key(file_bytes, public_key);
+        self.store
+            .save_attached_file(&encrypted, id, file_name)
+            .await?;
+        info!("Saved company file {file_name} with hash {file_hash} for company {id}");
+        Ok(File {
+            name: file_name.to_owned(),
+            hash: file_hash,
+        })
+    }
+
+    async fn open_and_decrypt_file(
+        &self,
+        id: &str,
+        file_name: &str,
+        private_key: &str,
+    ) -> Result<Vec<u8>> {
+        let read_file = self.store.open_attached_file(id, file_name).await?;
+        let decrypted =
+            util::rsa::decrypt_bytes_with_private_key(&read_file, private_key.to_owned());
+        Ok(decrypted)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct CompanyToReturn {
+    pub id: String,
+    pub legal_name: String,
+    pub country_of_registration: String,
+    pub city_of_registration: String,
+    pub postal_address: String,
+    pub legal_email: String,
+    pub registration_number: String,
+    pub registration_date: String,
+    pub proof_of_registration_file: Option<File>,
+    pub logo_file: Option<File>,
+    pub signatories: Vec<String>,
+    pub public_key: String,
+}
+
+impl CompanyToReturn {
+    fn from(id: String, company: Company, company_keys: CompanyKeys) -> CompanyToReturn {
+        CompanyToReturn {
+            id,
+            legal_name: company.legal_name,
+            country_of_registration: company.country_of_registration,
+            city_of_registration: company.city_of_registration,
+            postal_address: company.postal_address,
+            legal_email: company.legal_email,
+            registration_number: company.registration_number,
+            registration_date: company.registration_date,
+            proof_of_registration_file: company.proof_of_registration_file,
+            logo_file: company.logo_file,
+            signatories: company.signatories,
+            public_key: company_keys.public_key,
+        }
+    }
+}
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
 #[serde(crate = "rocket::serde")]

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -1,0 +1,49 @@
+use crate::web::data::File;
+use borsh_derive::{self, BorshDeserialize, BorshSerialize};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::persistence::company::CompanyStoreApi;
+
+use super::Result;
+
+#[async_trait]
+pub trait CompanyServiceApi: Send + Sync {}
+
+/// The company service is responsible for managing the companies
+#[derive(Clone)]
+pub struct CompanyService {
+    store: Arc<dyn CompanyStoreApi>,
+}
+
+impl CompanyService {
+    pub fn new(store: Arc<dyn CompanyStoreApi>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl CompanyServiceApi for CompanyService {}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct Company {
+    pub legal_name: String,
+    pub country_of_registration: String,
+    pub city_of_registration: String,
+    pub postal_address: String,
+    pub legal_email: String,
+    pub registration_number: String,
+    pub registration_date: String,
+    pub proof_of_registration_file: Option<File>,
+    pub logo_file: Option<File>,
+    pub signatories: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CompanyKeys {
+    pub private_key: String,
+    pub public_key: String,
+}

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -132,6 +132,12 @@ impl CompanyServiceApi for CompanyService {
     }
 
     async fn get_company_by_id(&self, id: &str) -> Result<CompanyToReturn> {
+        if !self.store.exists(id).await {
+            return Err(super::Error::Validation(String::from(
+                "No company with id: {id} found",
+            )));
+        }
+
         let company = self.store.get(id).await?;
         let keys = self.store.get_key_pair(id).await?;
         Ok(CompanyToReturn::from(id.to_owned(), company, keys))
@@ -234,6 +240,16 @@ impl CompanyServiceApi for CompanyService {
         company.logo_file = logo_file;
 
         self.store.update(id, &company).await?;
+
+        if let Some(upload_id) = logo_file_upload_id {
+            if let Err(e) = self
+                .file_upload_store
+                .remove_temp_upload_folder(&upload_id)
+                .await
+            {
+                error!("Error while cleaning up temporary file uploads for {upload_id}: {e}");
+            }
+        }
 
         Ok(())
     }
@@ -385,4 +401,622 @@ pub struct Company {
 pub struct CompanyKeys {
     pub private_key: String,
     pub public_key: String,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        persistence::{
+            self, company::MockCompanyStoreApi, contact::MockContactStoreApi,
+            file_upload::MockFileUploadStoreApi, identity::MockIdentityStoreApi,
+        },
+        service::{contact_service::IdentityPublicData, identity_service::Identity},
+        tests::test::{TEST_PRIVATE_KEY, TEST_PUB_KEY},
+    };
+    use libp2p::PeerId;
+    use mockall::predicate::{always, eq};
+    use std::collections::HashMap;
+
+    fn get_service(
+        mock_storage: MockCompanyStoreApi,
+        mock_file_upload_storage: MockFileUploadStoreApi,
+        mock_identity_storage: MockIdentityStoreApi,
+        mock_contacts_storage: MockContactStoreApi,
+    ) -> CompanyService {
+        CompanyService::new(
+            Arc::new(mock_storage),
+            Arc::new(mock_file_upload_storage),
+            Arc::new(mock_identity_storage),
+            Arc::new(mock_contacts_storage),
+        )
+    }
+
+    fn get_storages() -> (
+        MockCompanyStoreApi,
+        MockFileUploadStoreApi,
+        MockIdentityStoreApi,
+        MockContactStoreApi,
+    ) {
+        (
+            MockCompanyStoreApi::new(),
+            MockFileUploadStoreApi::new(),
+            MockIdentityStoreApi::new(),
+            MockContactStoreApi::new(),
+        )
+    }
+
+    fn get_baseline_company_data() -> (String, (Company, CompanyKeys)) {
+        (
+            "some_id".to_string(),
+            (
+                Company {
+                    legal_name: "some_name".to_string(),
+                    country_of_registration: "AT".to_string(),
+                    city_of_registration: "Vienna".to_string(),
+                    postal_address: "some address".to_string(),
+                    legal_email: "company@example.com".to_string(),
+                    registration_number: "some_number".to_string(),
+                    registration_date: "2012-01-01".to_string(),
+                    proof_of_registration_file: None,
+                    logo_file: None,
+                    signatories: vec![],
+                },
+                CompanyKeys {
+                    private_key: TEST_PRIVATE_KEY.to_string(),
+                    public_key: TEST_PUB_KEY.to_string(),
+                },
+            ),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_list_of_companies_baseline() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_get_all().returning(|| {
+            let mut map = HashMap::new();
+            let company_data = get_baseline_company_data();
+            map.insert(company_data.0, company_data.1);
+            Ok(map)
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+
+        let res = service.get_list_of_companies().await;
+        assert!(res.is_ok());
+        assert_eq!(res.as_ref().unwrap().len(), 1);
+        assert_eq!(res.as_ref().unwrap()[0].id, "some_id".to_string());
+        assert_eq!(
+            res.as_ref().unwrap()[0].public_key,
+            TEST_PUB_KEY.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_list_of_companies_propagates_persistence_errors() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_get_all().returning(|| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service.get_list_of_companies().await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_company_by_id_baseline() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage
+            .expect_get()
+            .returning(|_| Ok(get_baseline_company_data().1 .0));
+        storage
+            .expect_get_key_pair()
+            .returning(|_| Ok(get_baseline_company_data().1 .1));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+
+        let res = service.get_company_by_id("some_id").await;
+        assert!(res.is_ok());
+        assert_eq!(res.as_ref().unwrap().id, "some_id".to_string());
+        assert_eq!(res.as_ref().unwrap().public_key, TEST_PUB_KEY.to_string());
+    }
+
+    #[tokio::test]
+    async fn get_company_by_id_fails_if_company_doesnt_exist() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| false);
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service.get_company_by_id("some_id").await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_company_by_id_propagates_persistence_errors() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_get().returning(|_| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service.get_company_by_id("some_id").await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_company_baseline() {
+        let (mut storage, mut file_upload_store, mut identity_store, contact_store) =
+            get_storages();
+        storage
+            .expect_save_attached_file()
+            .returning(|_, _, _| Ok(()));
+        storage.expect_save_key_pair().returning(|_, _| Ok(()));
+        storage.expect_insert().returning(|_, _| Ok(()));
+        identity_store.expect_get().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(identity)
+        });
+        identity_store
+            .expect_get_peer_id()
+            .returning(|| Ok(PeerId::random()));
+        file_upload_store
+            .expect_read_temp_upload_files()
+            .returning(|_| {
+                Ok(vec![(
+                    "some_file".to_string(),
+                    "hello_world".as_bytes().to_vec(),
+                )])
+            });
+        file_upload_store
+            .expect_remove_temp_upload_folder()
+            .returning(|_| Ok(()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+
+        let res = service
+            .create_company(
+                "legal_name".to_string(),
+                "AT".to_string(),
+                "Vienna".to_string(),
+                "some Address".to_string(),
+                "company@example.com".to_string(),
+                "some_number".to_string(),
+                "2012-01-01".to_string(),
+                Some("some_file_id".to_string()),
+                Some("some_other_file_id".to_string()),
+            )
+            .await;
+        assert!(res.is_ok());
+        assert!(!res.as_ref().unwrap().id.is_empty());
+        assert_eq!(res.as_ref().unwrap().legal_name, "legal_name".to_string());
+        assert_eq!(
+            res.as_ref()
+                .unwrap()
+                .proof_of_registration_file
+                .as_ref()
+                .unwrap()
+                .name,
+            "some_file".to_string()
+        );
+        assert_eq!(
+            res.as_ref().unwrap().logo_file.as_ref().unwrap().name,
+            "some_file".to_string()
+        );
+        assert!(!res.as_ref().unwrap().public_key.is_empty());
+    }
+
+    #[tokio::test]
+    async fn create_company_propagates_persistence_errors() {
+        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        storage.expect_save_key_pair().returning(|_, _| Ok(()));
+        storage.expect_insert().returning(|_, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        identity_store.expect_get().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(identity)
+        });
+        identity_store
+            .expect_get_peer_id()
+            .returning(|| Ok(PeerId::random()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .create_company(
+                "legal_name".to_string(),
+                "AT".to_string(),
+                "Vienna".to_string(),
+                "some Address".to_string(),
+                "company@example.com".to_string(),
+                "some_number".to_string(),
+                "2012-01-01".to_string(),
+                None,
+                None,
+            )
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn edit_company_baseline() {
+        let (mut storage, mut file_upload_store, mut identity_store, contact_store) =
+            get_storages();
+        storage
+            .expect_get()
+            .returning(|_| Ok(get_baseline_company_data().1 .0));
+        storage.expect_exists().returning(|_| true);
+        storage.expect_update().returning(|_, _| Ok(()));
+        storage
+            .expect_save_attached_file()
+            .returning(|_, _, _| Ok(()));
+        identity_store.expect_get().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(identity)
+        });
+        file_upload_store
+            .expect_read_temp_upload_files()
+            .returning(|_| {
+                Ok(vec![(
+                    "some_file".to_string(),
+                    "hello_world".as_bytes().to_vec(),
+                )])
+            });
+        file_upload_store
+            .expect_remove_temp_upload_folder()
+            .returning(|_| Ok(()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .edit_company(
+                "some_id",
+                Some("legal_name".to_string()),
+                Some("some Address".to_string()),
+                Some("company@example.com".to_string()),
+                Some("some_file_id".to_string()),
+            )
+            .await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn edit_company_fails_if_company_doesnt_exist() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| false);
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .edit_company(
+                "some_id",
+                Some("legal_name".to_string()),
+                Some("some Address".to_string()),
+                Some("company@example.com".to_string()),
+                None,
+            )
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn edit_company_propagates_persistence_errors() {
+        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        storage
+            .expect_get()
+            .returning(|_| Ok(get_baseline_company_data().1 .0));
+        storage.expect_exists().returning(|_| true);
+        storage.expect_update().returning(|_, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        identity_store.expect_get().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(identity)
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .edit_company(
+                "some_id",
+                Some("legal_name".to_string()),
+                Some("some Address".to_string()),
+                Some("company@example.com".to_string()),
+                None,
+            )
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_signatory_baseline() {
+        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_update().returning(|_, _| Ok(()));
+        contact_store.expect_get_map().returning(|| {
+            let mut map = HashMap::new();
+            let mut identity = IdentityPublicData::new_empty();
+            identity.peer_id = "new_signatory_node_id".to_string();
+            map.insert("my best friend".to_string(), identity);
+            Ok(map)
+        });
+        storage
+            .expect_get()
+            .returning(|_| Ok(get_baseline_company_data().1 .0));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn add_signatory_fails_if_signatory_not_in_contacts() {
+        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        contact_store
+            .expect_get_map()
+            .returning(|| Ok(HashMap::new()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_signatory_fails_if_company_doesnt_exist() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| false);
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_signatory_fails_if_signatory_is_already_signatory() {
+        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        contact_store.expect_get_map().returning(|| {
+            let mut map = HashMap::new();
+            let mut identity = IdentityPublicData::new_empty();
+            identity.peer_id = "new_signatory_node_id".to_string();
+            map.insert("my best friend".to_string(), identity);
+            Ok(map)
+        });
+        storage.expect_get().returning(|_| {
+            let mut data = get_baseline_company_data().1 .0;
+            data.signatories.push("new_signatory_node_id".to_string());
+            Ok(data)
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn add_signatory_propagates_persistence_errors() {
+        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        contact_store.expect_get_map().returning(|| {
+            let mut map = HashMap::new();
+            let mut identity = IdentityPublicData::new_empty();
+            identity.peer_id = "new_signatory_node_id".to_string();
+            map.insert("my best friend".to_string(), identity);
+            Ok(map)
+        });
+        storage.expect_update().returning(|_, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        storage
+            .expect_get()
+            .returning(|_| Ok(get_baseline_company_data().1 .0));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_signatory_baseline() {
+        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_get().returning(|_| {
+            let mut data = get_baseline_company_data().1 .0;
+            data.signatories.push("new_signatory_node_id".to_string());
+            data.signatories
+                .push("some_other_dude_or_dudette".to_string());
+            Ok(data)
+        });
+        identity_store
+            .expect_get_peer_id()
+            .returning(|| Ok(PeerId::random()));
+        storage.expect_update().returning(|_, _| Ok(()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn remove_signatory_fails_if_company_doesnt_exist() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| false);
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_signatory_removing_self_removes_company() {
+        let peer_id = PeerId::random();
+        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_get().returning(move |_| {
+            let mut data = get_baseline_company_data().1 .0;
+            data.signatories.push("the founder".to_string());
+            data.signatories.push(peer_id.to_string());
+            Ok(data)
+        });
+        identity_store
+            .expect_get_peer_id()
+            .returning(move || Ok(peer_id));
+        storage.expect_update().returning(|_, _| Ok(()));
+        storage.expect_remove().returning(|_| Ok(()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .remove_signatory("some_id", peer_id.to_string())
+            .await;
+        assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn remove_signatory_fails_if_signatory_is_not_in_company() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_get().returning(|_| {
+            let mut data = get_baseline_company_data().1 .0;
+            data.signatories
+                .push("some_other_dude_or_dudette".to_string());
+            data.signatories.push("the_founder".to_string());
+            Ok(data)
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_signatory_fails_on_last_signatory() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_get().returning(|_| {
+            let mut data = get_baseline_company_data().1 .0;
+            data.signatories.push("the_founder".to_string());
+            Ok(data)
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn remove_signatory_propagates_persistence_errors() {
+        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        storage.expect_exists().returning(|_| true);
+        storage.expect_get().returning(|_| {
+            let mut data = get_baseline_company_data().1 .0;
+            data.signatories.push("new_signatory_node_id".to_string());
+            data.signatories
+                .push("some_other_dude_or_dudette".to_string());
+            Ok(data)
+        });
+        identity_store
+            .expect_get_peer_id()
+            .returning(|| Ok(PeerId::random()));
+        storage.expect_update().returning(|_, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let res = service
+            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn save_encrypt_open_decrypt_compare_hashes() {
+        let company_id = "00000000-0000-0000-0000-000000000000";
+        let file_name = "file_00000000-0000-0000-0000-000000000000.pdf";
+        let file_bytes = String::from("hello world").as_bytes().to_vec();
+        let expected_encrypted =
+            util::rsa::encrypt_bytes_with_public_key(&file_bytes, TEST_PUB_KEY);
+
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage
+            .expect_save_attached_file()
+            .with(always(), eq(company_id), eq(file_name))
+            .times(1)
+            .returning(|_, _, _| Ok(()));
+
+        storage
+            .expect_open_attached_file()
+            .with(eq(company_id), eq(file_name))
+            .times(1)
+            .returning(move |_, _| Ok(expected_encrypted.clone()));
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+
+        let file = service
+            .encrypt_and_save_uploaded_file(file_name, &file_bytes, company_id, TEST_PUB_KEY)
+            .await
+            .unwrap();
+        assert_eq!(
+            file.hash,
+            String::from("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+        );
+        assert_eq!(file.name, String::from(file_name));
+
+        let decrypted = service
+            .open_and_decrypt_file(company_id, file_name, TEST_PRIVATE_KEY)
+            .await
+            .unwrap();
+        assert_eq!(std::str::from_utf8(&decrypted).unwrap(), "hello world");
+    }
+
+    #[tokio::test]
+    async fn save_encrypt_propagates_write_file_error() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_save_attached_file().returning(|_, _, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+
+        assert!(service
+            .encrypt_and_save_uploaded_file("file_name", &[], "test", TEST_PUB_KEY)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn open_decrypt_propagates_read_file_error() {
+        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        storage.expect_open_attached_file().returning(|_, _| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+
+        assert!(service
+            .open_and_decrypt_file("test", "test", TEST_PRIVATE_KEY)
+            .await
+            .is_err());
+    }
 }

--- a/src/service/contact_service.rs
+++ b/src/service/contact_service.rs
@@ -1,5 +1,4 @@
 use borsh_derive::{self, BorshDeserialize, BorshSerialize};
-use rocket::FromForm;
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
@@ -136,9 +135,7 @@ fn as_contacts(identities: HashMap<String, IdentityPublicData>) -> Vec<Contact> 
         .collect()
 }
 
-#[derive(
-    BorshSerialize, BorshDeserialize, FromForm, Debug, Serialize, Deserialize, Clone, Eq, PartialEq,
-)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 #[serde(crate = "rocket::serde")]
 pub struct IdentityPublicData {
     pub peer_id: String,

--- a/src/service/file_upload_service.rs
+++ b/src/service/file_upload_service.rs
@@ -1,0 +1,336 @@
+use super::{Error, Result};
+use crate::constants::{MAX_FILE_NAME_CHARACTERS, MAX_FILE_SIZE_BYTES, VALID_FILE_MIME_TYPES};
+use crate::persistence::file_upload::FileUploadStoreApi;
+use crate::web::data::UploadFilesResponse;
+use crate::{persistence, util};
+use async_trait::async_trait;
+use log::error;
+use std::sync::Arc;
+
+#[async_trait]
+pub trait FileUploadServiceApi: Send + Sync {
+    /// validates the given uploaded file
+    async fn validate_attached_file(&self, file: &dyn util::file::UploadFileHandler) -> Result<()>;
+
+    /// uploads files for use in a bill
+    async fn upload_files(
+        &self,
+        files: Vec<&dyn util::file::UploadFileHandler>,
+    ) -> Result<UploadFilesResponse>;
+}
+
+#[derive(Clone)]
+pub struct FileUploadService {
+    file_upload_store: Arc<dyn FileUploadStoreApi>,
+}
+
+impl FileUploadService {
+    pub fn new(file_upload_store: Arc<dyn FileUploadStoreApi>) -> Self {
+        Self { file_upload_store }
+    }
+}
+
+#[async_trait]
+impl FileUploadServiceApi for FileUploadService {
+    async fn validate_attached_file(&self, file: &dyn util::file::UploadFileHandler) -> Result<()> {
+        if file.len() > MAX_FILE_SIZE_BYTES as u64 {
+            return Err(Error::Validation(format!(
+                "Maximum file size is {} bytes",
+                MAX_FILE_SIZE_BYTES
+            )));
+        }
+
+        let name = match file.name() {
+            Some(n) => n,
+            None => {
+                return Err(Error::Validation(String::from("File name needs to be set")));
+            }
+        };
+
+        if name.is_empty() || name.len() > MAX_FILE_NAME_CHARACTERS {
+            return Err(Error::Validation(format!(
+                "File name needs to have between 1 and {} characters",
+                MAX_FILE_NAME_CHARACTERS
+            )));
+        }
+
+        let detected_type = match file.detect_content_type().await.map_err(|e| {
+            error!("Could not detect content type for file {name}: {e}");
+            Error::Validation(String::from("Could not detect content type for file"))
+        })? {
+            Some(t) => t,
+            None => {
+                return Err(Error::Validation(String::from(
+                    "Unknown file type detected",
+                )))
+            }
+        };
+
+        if !VALID_FILE_MIME_TYPES.contains(&detected_type.as_str()) {
+            return Err(Error::Validation(String::from(
+                "Invalid file type detected",
+            )));
+        }
+        Ok(())
+    }
+
+    async fn upload_files(
+        &self,
+        files: Vec<&dyn util::file::UploadFileHandler>,
+    ) -> Result<UploadFilesResponse> {
+        // create a new random id
+        let file_upload_id = util::get_uuid_v4().to_string();
+        // create a folder to store the files
+        self.file_upload_store
+            .create_temp_upload_folder(&file_upload_id)
+            .await?;
+        // sanitize and randomize file name and write file into the temporary folder
+        for file in files {
+            let file_name = util::file::generate_unique_filename(
+                &util::file::sanitize_filename(
+                    &file
+                        .name()
+                        .ok_or(Error::Validation(String::from("Invalid file name")))?,
+                ),
+                file.extension(),
+            );
+            let read_file = file.get_contents().await.map_err(persistence::Error::Io)?;
+            self.file_upload_store
+                .write_temp_upload_file(&file_upload_id, &file_name, &read_file)
+                .await?;
+        }
+        Ok(UploadFilesResponse { file_upload_id })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use persistence::file_upload::MockFileUploadStoreApi;
+    use std::sync::Arc;
+    use util::file::MockUploadFileHandler;
+
+    fn get_service(mock_storage: MockFileUploadStoreApi) -> FileUploadService {
+        FileUploadService::new(Arc::new(mock_storage))
+    }
+
+    #[tokio::test]
+    async fn upload_files_baseline() {
+        let file_bytes = String::from("hello world").as_bytes().to_vec();
+        let mut storage = MockFileUploadStoreApi::new();
+        storage
+            .expect_write_temp_upload_file()
+            .returning(|_, _, _| Ok(()));
+        storage
+            .expect_create_temp_upload_folder()
+            .returning(|_| Ok(()));
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name()
+            .returning(|| Some(String::from("invoice")));
+        file.expect_extension()
+            .returning(|| Some(String::from("pdf")));
+        file.expect_get_contents()
+            .returning(move || Ok(file_bytes.clone()));
+        let service = get_service(storage);
+
+        let res = service.upload_files(vec![&file]).await;
+        assert!(res.is_ok());
+        assert_eq!(
+            res.unwrap().file_upload_id,
+            "00000000-0000-0000-0000-000000000000".to_owned()
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_files_baseline_fails_on_folder_creation() {
+        let file_bytes = String::from("hello world").as_bytes().to_vec();
+        let mut storage = MockFileUploadStoreApi::new();
+        storage.expect_create_temp_upload_folder().returning(|_| {
+            Err(persistence::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "test error",
+            )))
+        });
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name()
+            .returning(|| Some(String::from("invoice")));
+        file.expect_extension()
+            .returning(|| Some(String::from("pdf")));
+        file.expect_get_contents()
+            .returning(move || Ok(file_bytes.clone()));
+        let service = get_service(storage);
+
+        let res = service.upload_files(vec![&file]).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn upload_files_baseline_fails_on_file_creation() {
+        let mut storage = MockFileUploadStoreApi::new();
+        storage
+            .expect_create_temp_upload_folder()
+            .returning(|_| Ok(()));
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name()
+            .returning(|| Some(String::from("invoice")));
+        file.expect_extension()
+            .returning(|| Some(String::from("pdf")));
+        file.expect_get_contents()
+            .returning(|| Err(std::io::Error::new(std::io::ErrorKind::Other, "test error")));
+        let service = get_service(storage);
+
+        let res = service.upload_files(vec![&file]).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn upload_files_baseline_fails_on_file_name_errors() {
+        let mut storage = MockFileUploadStoreApi::new();
+        storage
+            .expect_create_temp_upload_folder()
+            .returning(|_| Ok(()));
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name().returning(|| None);
+        let service = get_service(storage);
+
+        let res = service.upload_files(vec![&file]).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn upload_files_baseline_fails_on_file_read_errors() {
+        let file_bytes = String::from("hello world").as_bytes().to_vec();
+        let mut storage = MockFileUploadStoreApi::new();
+        storage
+            .expect_write_temp_upload_file()
+            .returning(|_, _, _| {
+                Err(persistence::Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "test error",
+                )))
+            });
+        storage
+            .expect_create_temp_upload_folder()
+            .returning(|_| Ok(()));
+        let mut file = MockUploadFileHandler::new();
+        file.expect_name()
+            .returning(|| Some(String::from("invoice")));
+        file.expect_extension()
+            .returning(|| Some(String::from("pdf")));
+        file.expect_get_contents()
+            .returning(move || Ok(file_bytes.clone()));
+        let service = get_service(storage);
+
+        let res = service.upload_files(vec![&file]).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_size() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len()
+            .returning(move || MAX_FILE_SIZE_BYTES as u64 * 2);
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_name() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name().returning(move || None);
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_name_empty() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name().returning(move || Some(String::from("")));
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_name_length() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name()
+            .returning(move || Some("abc".repeat(100)));
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_type_error() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name()
+            .returning(move || Some(String::from("goodname")));
+        file.expect_detect_content_type()
+            .returning(move || Err(std::io::Error::new(std::io::ErrorKind::Other, "test error")));
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_type_invalid() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name()
+            .returning(move || Some(String::from("goodname")));
+        file.expect_detect_content_type()
+            .returning(move || Ok(None));
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_file_type_not_in_list() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name()
+            .returning(move || Some(String::from("goodname")));
+        file.expect_detect_content_type()
+            .returning(move || Ok(Some(String::from("invalidfile"))));
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn validate_attached_file_checks_valid() {
+        let mut file = MockUploadFileHandler::new();
+        file.expect_len().returning(move || 100);
+        file.expect_name()
+            .returning(move || Some(String::from("goodname")));
+        file.expect_detect_content_type()
+            .returning(move || Ok(Some(String::from("application/pdf"))));
+
+        let service = get_service(MockFileUploadStoreApi::new());
+        let res = service.validate_attached_file(&file).await;
+
+        assert!(res.is_ok());
+    }
+}

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -6,7 +6,6 @@ use libp2p::identity::Keypair;
 use libp2p::PeerId;
 use openssl::{pkey::Private, rsa::Rsa};
 use rocket::serde::{Deserialize, Serialize};
-use rocket::FromForm;
 use std::sync::Arc;
 
 #[async_trait]
@@ -138,9 +137,7 @@ pub struct IdentityWithAll {
     pub key_pair: Keypair,
 }
 
-#[derive(
-    BorshSerialize, BorshDeserialize, FromForm, Debug, Serialize, Deserialize, Clone, PartialEq, Eq,
-)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(crate = "rocket::serde")]
 pub struct Identity {
     pub name: String,

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -182,7 +182,12 @@ pub async fn create_service_context(
 
     let company_store =
         FileBasedCompanyStore::new(&config.data_dir, "company", "data", "keys").await?;
-    let company_service = CompanyService::new(Arc::new(company_store), file_upload_store.clone());
+    let company_service = CompanyService::new(
+        Arc::new(company_store),
+        file_upload_store.clone(),
+        identity_store.clone(),
+        contact_store.clone(),
+    );
     let file_upload_service = FileUploadService::new(file_upload_store);
 
     Ok(ServiceContext::new(

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -176,19 +176,22 @@ pub async fn create_service_context(
     shutdown_sender: broadcast::Sender<bool>,
     db: DbContext,
 ) -> Result<ServiceContext> {
-    let contact_service = ContactService::new(client.clone(), db.contact_store);
-    let bill_service = BillService::new(client.clone(), db.bill_store, db.identity_store.clone());
-    let identity_service = IdentityService::new(client.clone(), db.identity_store);
-
-    let company_store =
-        FileBasedCompanyStore::new(&config.data_dir, "company", "data", "keys").await?;
-    let company_service = CompanyService::new(
-        Arc::new(company_store),
-        file_upload_store.clone(),
-        identity_store.clone(),
-        contact_store.clone(),
+    let contact_service = ContactService::new(client.clone(), db.contact_store.clone());
+    let bill_service = BillService::new(
+        client.clone(),
+        db.bill_store,
+        db.identity_store.clone(),
+        db.file_upload_store.clone(),
     );
-    let file_upload_service = FileUploadService::new(file_upload_store);
+    let identity_service = IdentityService::new(client.clone(), db.identity_store.clone());
+
+    let company_service = CompanyService::new(
+        db.company_store,
+        db.file_upload_store.clone(),
+        db.identity_store,
+        db.contact_store,
+    );
+    let file_upload_service = FileUploadService::new(db.file_upload_store);
 
     Ok(ServiceContext::new(
         config,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,7 +4,7 @@ pub mod rsa;
 use crate::{
     constants::USEDNET, service::bill_service::BitcreditBill, service::identity_service::Identity,
 };
-use bitcoin::secp256k1::Scalar;
+use bitcoin::{secp256k1::Scalar, Network, PrivateKey, PublicKey};
 use openssl::sha::sha256;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -18,6 +18,18 @@ pub fn get_uuid_v4() -> Uuid {
 pub fn get_uuid_v4() -> Uuid {
     use uuid::uuid;
     uuid!("00000000-0000-0000-0000-000000000000")
+}
+
+pub fn create_bitcoin_keypair(used_network: Network) -> (PrivateKey, PublicKey) {
+    let key_context = bitcoin::secp256k1::Secp256k1::new();
+    let private_key = bitcoin::PrivateKey::new(
+        key_context
+            .generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
+            .0,
+        used_network,
+    );
+    let public_key = private_key.public_key(&key_context);
+    (private_key, public_key)
 }
 
 pub fn sha256_hash(bytes: &[u8]) -> String {

--- a/src/web/data.rs
+++ b/src/web/data.rs
@@ -24,6 +24,11 @@ pub struct UploadBillFilesForm<'r> {
     pub files: Vec<TempFile<'r>>,
 }
 
+#[derive(Debug, FromForm)]
+pub struct UploadFileForm<'r> {
+    pub file: TempFile<'r>,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 pub struct EndorseBitcreditBillPayload {
@@ -124,4 +129,17 @@ impl NodeId {
     pub fn new(peer_id: String) -> Self {
         Self { id: peer_id }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct UploadFilesResponse {
+    pub file_upload_id: String,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct File {
+    pub name: String,
+    pub hash: String,
 }

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -1,13 +1,12 @@
 use crate::blockchain::Chain;
 use crate::external::mint::{accept_mint_bitcredit, request_to_mint_bitcredit};
-use crate::service::bill_service::UploadBillFilesResponse;
 use crate::service::{contact_service::IdentityPublicData, Result};
 use crate::util::file::{detect_content_type_for_bytes, UploadFileHandler};
 use crate::web::data::{
     AcceptBitcreditBillPayload, AcceptMintBitcreditBillPayload, BitcreditBillPayload,
     EndorseBitcreditBillPayload, MintBitcreditBillPayload, RequestToAcceptBitcreditBillPayload,
     RequestToMintBitcreditBillPayload, RequestToPayBitcreditBillPayload, SellBitcreditBillPayload,
-    UploadBillFilesForm,
+    UploadBillFilesForm, UploadFilesResponse,
 };
 use crate::{external, service};
 use crate::{
@@ -108,7 +107,7 @@ pub async fn search_bill(state: &State<ServiceContext>) -> Result<Status> {
 pub async fn upload_files(
     state: &State<ServiceContext>,
     files_upload_form: Form<UploadBillFilesForm<'_>>,
-) -> Result<Json<UploadBillFilesResponse>> {
+) -> Result<Json<UploadFilesResponse>> {
     if !state.identity_service.identity_exists().await {
         return Err(service::Error::PreconditionFailed);
     }

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -124,11 +124,14 @@ pub async fn upload_files(
 
     // Validate Files
     for file in &upload_file_handlers {
-        state.bill_service.validate_attached_file(*file).await?;
+        state
+            .file_upload_service
+            .validate_attached_file(*file)
+            .await?;
     }
 
     let file_upload_response = state
-        .bill_service
+        .file_upload_service
         .upload_files(upload_file_handlers)
         .await?;
 

--- a/src/web/handlers/company/data.rs
+++ b/src/web/handlers/company/data.rs
@@ -1,21 +1,4 @@
-use crate::web::data::File;
 use rocket::serde::{Deserialize, Serialize};
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(crate = "rocket::serde")]
-pub struct CompanyToReturn {
-    pub id: String,
-    pub legal_name: String,
-    pub country_of_registration: String,
-    pub city_of_registration: String,
-    pub postal_address: String,
-    pub legal_email: String,
-    pub registration_number: String,
-    pub registration_date: String,
-    pub proof_of_registration_file: Option<File>,
-    pub logo_file: Option<File>,
-    pub public_key: String,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(crate = "rocket::serde")]

--- a/src/web/handlers/company/data.rs
+++ b/src/web/handlers/company/data.rs
@@ -1,0 +1,56 @@
+use crate::web::data::File;
+use rocket::serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct CompanyToReturn {
+    pub id: String,
+    pub legal_name: String,
+    pub country_of_registration: String,
+    pub city_of_registration: String,
+    pub postal_address: String,
+    pub legal_email: String,
+    pub registration_number: String,
+    pub registration_date: String,
+    pub proof_of_registration_file: Option<File>,
+    pub logo_file: Option<File>,
+    pub public_key: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct CreateCompanyPayload {
+    pub legal_name: String,
+    pub country_of_registration: String,
+    pub city_of_registration: String,
+    pub postal_address: String,
+    pub legal_email: String,
+    pub registration_number: String,
+    pub registration_date: String,
+    pub proof_of_registration_file_upload_id: Option<String>,
+    pub logo_file_upload_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct EditCompanyPayload {
+    pub id: String,
+    pub legal_name: Option<String>,
+    pub legal_email: Option<String>,
+    pub postal_address: Option<String>,
+    pub logo_file_upload_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct AddSignatoryPayload {
+    pub id: String,
+    pub signatory_node_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(crate = "rocket::serde")]
+pub struct RemoveSignatoryPayload {
+    pub id: String,
+    pub signatory_node_id: String,
+}

--- a/src/web/handlers/company/mod.rs
+++ b/src/web/handlers/company/mod.rs
@@ -1,0 +1,81 @@
+use crate::{
+    service::{Error, Result, ServiceContext},
+    util::file::UploadFileHandler,
+    web::data::{UploadFileForm, UploadFilesResponse},
+};
+use data::{AddSignatoryPayload, CreateCompanyPayload, EditCompanyPayload, RemoveSignatoryPayload};
+use rocket::{form::Form, get, post, put, serde::json::Json, State};
+
+pub mod data;
+
+#[get("/list")]
+pub async fn list(state: &State<ServiceContext>) -> Result<Json<Vec<data::CompanyToReturn>>> {
+    Ok(Json(vec![]))
+}
+
+#[post("/upload_file", data = "<file_upload_form>")]
+pub async fn upload_file(
+    state: &State<ServiceContext>,
+    file_upload_form: Form<UploadFileForm<'_>>,
+) -> Result<Json<UploadFilesResponse>> {
+    if !state.identity_service.identity_exists().await {
+        return Err(Error::PreconditionFailed);
+    }
+
+    let file = &file_upload_form.file;
+    let upload_file_handler: &dyn UploadFileHandler = file as &dyn UploadFileHandler;
+
+    // state.file_service.validate_attached_file(*file).await?;
+
+    // let file_upload_response = state
+    //     .file_service
+    //     .upload_file(upload_file_handler)
+    //     .await?;
+
+    // Ok(Json(file_upload_response))
+    return Err(Error::PreconditionFailed);
+}
+
+#[get("/<id>")]
+pub async fn detail(
+    state: &State<ServiceContext>,
+    id: &str,
+) -> Result<Json<data::CompanyToReturn>> {
+    return Err(Error::PreconditionFailed);
+}
+
+#[post("/create", format = "json", data = "<create_company_payload>")]
+pub async fn create(
+    state: &State<ServiceContext>,
+    create_company_payload: Json<CreateCompanyPayload>,
+) -> Result<Json<data::CompanyToReturn>> {
+    return Err(Error::PreconditionFailed);
+}
+
+#[put("/edit", format = "json", data = "<edit_company_payload>")]
+pub async fn edit(
+    state: &State<ServiceContext>,
+    edit_company_payload: Json<EditCompanyPayload>,
+) -> Result<()> {
+    return Err(Error::PreconditionFailed);
+}
+
+#[put("/add_signatory", format = "json", data = "<add_signatory_payload>")]
+pub async fn add_signatory(
+    state: &State<ServiceContext>,
+    add_signatory_payload: Json<AddSignatoryPayload>,
+) -> Result<()> {
+    return Err(Error::PreconditionFailed);
+}
+
+#[put(
+    "/remove_signatory",
+    format = "json",
+    data = "<remove_signatory_payload>"
+)]
+pub async fn remove_signatory(
+    state: &State<ServiceContext>,
+    remove_signatory_payload: Json<RemoveSignatoryPayload>,
+) -> Result<()> {
+    return Err(Error::PreconditionFailed);
+}

--- a/src/web/handlers/company/mod.rs
+++ b/src/web/handlers/company/mod.rs
@@ -1,16 +1,41 @@
 use crate::{
-    service::{Error, Result, ServiceContext},
-    util::file::UploadFileHandler,
+    service::{self, company_service::CompanyToReturn, Error, Result, ServiceContext},
+    util::file::{detect_content_type_for_bytes, UploadFileHandler},
     web::data::{UploadFileForm, UploadFilesResponse},
 };
 use data::{AddSignatoryPayload, CreateCompanyPayload, EditCompanyPayload, RemoveSignatoryPayload};
-use rocket::{form::Form, get, post, put, serde::json::Json, State};
+use rocket::{form::Form, get, http::ContentType, post, put, serde::json::Json, State};
 
 pub mod data;
 
 #[get("/list")]
-pub async fn list(state: &State<ServiceContext>) -> Result<Json<Vec<data::CompanyToReturn>>> {
-    Ok(Json(vec![]))
+pub async fn list(state: &State<ServiceContext>) -> Result<Json<Vec<CompanyToReturn>>> {
+    let companies = state.company_service.get_list_of_companies().await?;
+    Ok(Json(companies))
+}
+
+#[get("/file/<id>/<file_name>")]
+pub async fn get_file(
+    state: &State<ServiceContext>,
+    id: &str,
+    file_name: &str,
+) -> Result<(ContentType, Vec<u8>)> {
+    let private_key = state.identity_service.get_identity().await?.private_key_pem;
+
+    let file_bytes = state
+        .company_service
+        .open_and_decrypt_file(id, file_name, &private_key)
+        .await?;
+
+    let content_type = match detect_content_type_for_bytes(&file_bytes) {
+        None => None,
+        Some(t) => ContentType::parse_flexible(&t),
+    }
+    .ok_or(service::Error::Validation(String::from(
+        "Content Type of the requested file could not be determined",
+    )))?;
+
+    Ok((content_type, file_bytes))
 }
 
 #[post("/upload_file", data = "<file_upload_form>")]
@@ -25,31 +50,46 @@ pub async fn upload_file(
     let file = &file_upload_form.file;
     let upload_file_handler: &dyn UploadFileHandler = file as &dyn UploadFileHandler;
 
-    // state.file_service.validate_attached_file(*file).await?;
+    state
+        .file_upload_service
+        .validate_attached_file(upload_file_handler)
+        .await?;
 
-    // let file_upload_response = state
-    //     .file_service
-    //     .upload_file(upload_file_handler)
-    //     .await?;
+    let file_upload_response = state
+        .file_upload_service
+        .upload_files(vec![upload_file_handler])
+        .await?;
 
-    // Ok(Json(file_upload_response))
-    return Err(Error::PreconditionFailed);
+    Ok(Json(file_upload_response))
 }
 
 #[get("/<id>")]
-pub async fn detail(
-    state: &State<ServiceContext>,
-    id: &str,
-) -> Result<Json<data::CompanyToReturn>> {
-    return Err(Error::PreconditionFailed);
+pub async fn detail(state: &State<ServiceContext>, id: &str) -> Result<Json<CompanyToReturn>> {
+    let company = state.company_service.get_company_by_id(id).await?;
+    Ok(Json(company))
 }
 
 #[post("/create", format = "json", data = "<create_company_payload>")]
 pub async fn create(
     state: &State<ServiceContext>,
     create_company_payload: Json<CreateCompanyPayload>,
-) -> Result<Json<data::CompanyToReturn>> {
-    return Err(Error::PreconditionFailed);
+) -> Result<Json<CompanyToReturn>> {
+    let payload = create_company_payload.0;
+    let created_company = state
+        .company_service
+        .create_company(
+            payload.legal_name,
+            payload.country_of_registration,
+            payload.city_of_registration,
+            payload.postal_address,
+            payload.legal_email,
+            payload.registration_number,
+            payload.registration_date,
+            payload.proof_of_registration_file_upload_id,
+            payload.logo_file_upload_id,
+        )
+        .await?;
+    Ok(Json(created_company))
 }
 
 #[put("/edit", format = "json", data = "<edit_company_payload>")]
@@ -57,7 +97,18 @@ pub async fn edit(
     state: &State<ServiceContext>,
     edit_company_payload: Json<EditCompanyPayload>,
 ) -> Result<()> {
-    return Err(Error::PreconditionFailed);
+    let payload = edit_company_payload.0;
+    state
+        .company_service
+        .edit_company(
+            &payload.id,
+            payload.legal_name,
+            payload.legal_email,
+            payload.postal_address,
+            payload.logo_file_upload_id,
+        )
+        .await?;
+    Ok(())
 }
 
 #[put("/add_signatory", format = "json", data = "<add_signatory_payload>")]
@@ -65,7 +116,12 @@ pub async fn add_signatory(
     state: &State<ServiceContext>,
     add_signatory_payload: Json<AddSignatoryPayload>,
 ) -> Result<()> {
-    return Err(Error::PreconditionFailed);
+    let payload = add_signatory_payload.0;
+    state
+        .company_service
+        .add_signatory(&payload.id, payload.signatory_node_id)
+        .await?;
+    Ok(())
 }
 
 #[put(
@@ -77,5 +133,10 @@ pub async fn remove_signatory(
     state: &State<ServiceContext>,
     remove_signatory_payload: Json<RemoveSignatoryPayload>,
 ) -> Result<()> {
-    return Err(Error::PreconditionFailed);
+    let payload = remove_signatory_payload.0;
+    state
+        .company_service
+        .remove_signatory(&payload.id, payload.signatory_node_id)
+        .await?;
+    Ok(())
 }

--- a/src/web/handlers/mod.rs
+++ b/src/web/handlers/mod.rs
@@ -4,6 +4,7 @@ use rocket::serde::json::Json;
 use rocket::{get, Shutdown, State};
 
 pub mod bill;
+pub mod company;
 pub mod contacts;
 pub mod identity;
 pub mod quotes;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -5,11 +5,10 @@ use rocket::fs::FileServer;
 use rocket::http::Header;
 use rocket::{catch, catchers, routes, Build, Config, Request, Response, Rocket};
 
-mod data;
+pub mod data;
 mod handlers;
 
 use crate::constants::MAX_FILE_SIZE_BYTES;
-pub use data::RequestToMintBitcreditBillPayload;
 use rocket::data::ByteUnit;
 use rocket::figment::Figment;
 
@@ -47,6 +46,14 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
                 handlers::contacts::edit_contact,
                 handlers::contacts::remove_contact,
                 handlers::contacts::return_contacts
+            ],
+        )
+        .mount(
+            "/company",
+            routes![
+                handlers::company::list,
+                handlers::company::detail,
+                handlers::company::upload_file,
             ],
         )
         .mount(

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -53,7 +53,12 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             routes![
                 handlers::company::list,
                 handlers::company::detail,
+                handlers::company::get_file,
                 handlers::company::upload_file,
+                handlers::company::create,
+                handlers::company::edit,
+                handlers::company::add_signatory,
+                handlers::company::remove_signatory,
             ],
         )
         .mount(


### PR DESCRIPTION
This is the first step for implementing #139 

It refactors file uploading to a `file_upload_store` and `file_upload_service`, so we can re-use that logic across multiple areas.

It adds the following infrastructure for Company identity:
* Data models
* Persistence
* Service
* Web endpoints

And a basic implementation of all endpoints I sketched out on Postman.

What's missing are tests and going through the different interactions to see if they are fine as they are API-wise.

Further, once this is merged, I will start working on the DHT-based logic, of how to propagate companies across signatories etc.