### PR TITLE
Pick Bitcoin network base on environment setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ nostr-sdk = "0.36.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 infer = { version = "0.3", default-features = false }
 surrealdb = "2"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 mockall = "0.13.0"

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -6,18 +6,18 @@ use crate::bill::get_path_for_bill;
 use crate::blockchain::OperationCode::{
     Accept, Endorse, Issue, Mint, RequestToAccept, RequestToPay, Sell,
 };
-use crate::Config;
-use clap::Parser;
 use crate::external;
 use crate::service::bill_service::BillKeys;
 use crate::service::bill_service::BitcreditBill;
 use crate::service::contact_service::IdentityPublicData;
+use crate::Config;
 use crate::{
     bill::{bill_from_byte_array, read_keys_from_bill_file},
     util::rsa::decrypt_bytes,
 };
 use borsh_derive::BorshDeserialize;
 use borsh_derive::BorshSerialize;
+use clap::Parser;
 use log::error;
 use log::warn;
 use openssl::pkey::Private;

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -15,7 +15,6 @@ use crate::{
     bill::{bill_from_byte_array, read_keys_from_bill_file},
     util::rsa::decrypt_bytes,
 };
-use bitcoin::Network;
 use borsh_derive::BorshDeserialize;
 use borsh_derive::BorshSerialize;
 use log::error;
@@ -595,13 +594,7 @@ impl Chain {
             .unwrap();
         let pub_key_bill = bitcoin::PublicKey::new(public_key_bill);
 
-        let network_kind = match &USERNETWORK {
-            Bitcoin => Network::Bitcoin,
-            Testnet => Network::Testnet,
-            _ => Network::Testnet,
-        };
-
-        bitcoin::Address::p2pkh(pub_key_bill, network_kind).to_string()
+        bitcoin::Address::p2pkh(pub_key_bill, *USERNETWORK).to_string()
     }
 
     /// This function extracts the first block's data, decrypts it using the private key

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -6,7 +6,8 @@ use crate::bill::get_path_for_bill;
 use crate::blockchain::OperationCode::{
     Accept, Endorse, Issue, Mint, RequestToAccept, RequestToPay, Sell,
 };
-use crate::constants::USEDNET;
+use crate::Config;
+use clap::Parser;
 use crate::external;
 use crate::service::bill_service::BillKeys;
 use crate::service::bill_service::BitcreditBill;
@@ -593,8 +594,9 @@ impl Chain {
             .combine(&public_key_bill_seller.inner)
             .unwrap();
         let pub_key_bill = bitcoin::PublicKey::new(public_key_bill);
-
-        bitcoin::Address::p2pkh(pub_key_bill, USEDNET).to_string()
+        let conf = Config::try_parse();
+        let network = conf.expect("Unable to fetch config").bitcoin_network();
+        bitcoin::Address::p2pkh(pub_key_bill, network).to_string()
     }
 
     /// This function extracts the first block's data, decrypts it using the private key

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -10,14 +10,14 @@ use crate::external;
 use crate::service::bill_service::BillKeys;
 use crate::service::bill_service::BitcreditBill;
 use crate::service::contact_service::IdentityPublicData;
-use crate::Config;
+use crate::USERNETWORK;
 use crate::{
     bill::{bill_from_byte_array, read_keys_from_bill_file},
     util::rsa::decrypt_bytes,
 };
+use bitcoin::Network;
 use borsh_derive::BorshDeserialize;
 use borsh_derive::BorshSerialize;
-use clap::Parser;
 use log::error;
 use log::warn;
 use openssl::pkey::Private;
@@ -594,9 +594,14 @@ impl Chain {
             .combine(&public_key_bill_seller.inner)
             .unwrap();
         let pub_key_bill = bitcoin::PublicKey::new(public_key_bill);
-        let conf = Config::try_parse();
-        let network = conf.expect("Unable to fetch config").bitcoin_network();
-        bitcoin::Address::p2pkh(pub_key_bill, network).to_string()
+
+        let network_kind = match &USERNETWORK {
+            Bitcoin => Network::Bitcoin,
+            Testnet => Network::Testnet,
+            _ => Network::Testnet,
+        };
+
+        bitcoin::Address::p2pkh(pub_key_bill, network_kind).to_string()
     }
 
     /// This function extracts the first block's data, decrypts it using the private key

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,5 +48,4 @@ impl Config {
             _ => Network::Testnet,
         }
     }
-
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use bitcoin::Network;
 use clap::Parser;
 use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
@@ -24,6 +25,8 @@ pub struct Config {
     pub surreal_db_connection: String,
     #[arg(default_value_t = false, long, env = "TERMINAL_CLIENT")]
     pub terminal_client: bool,
+    #[arg(default_value_t = String::from("development"),  env = "development")]
+    pub environment: String,
 }
 
 impl Config {
@@ -37,4 +40,14 @@ impl Config {
             .with(Protocol::Tcp(self.p2p_port));
         Ok(res)
     }
+
+    pub fn bitcoin_network(&self) -> Network {
+        match self.environment.as_str() {
+            "production" => Network::Bitcoin,
+            "development" => Network::Testnet,
+            _ => Network::Testnet,
+        }
+    }
+
+  
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,5 +49,4 @@ impl Config {
         }
     }
 
-  
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,3 @@
-use bitcoin::Network;
 use std::net::Ipv4Addr;
 
 // General
@@ -22,8 +21,6 @@ pub const BOOTSTRAP_FOLDER_PATH: &str = "bootstrap";
 pub const QUOTE_MAP_FILE_PATH: &str = "quotes/quotes";
 pub const BOOTSTRAP_NODES_FILE_PATH: &str = "bootstrap/bootstrap_nodes.json";
 
-// Bitcoin
-pub const USEDNET: Network = Network::Testnet; // use Network::Bitcoin for Mainnet
 pub const COMPOUNDING_INTEREST_RATE_ZERO: u64 = 0;
 // pub const BILL_VALIDITY_PERIOD: u64 = 90;
 

--- a/src/external/bitcoin.rs
+++ b/src/external/bitcoin.rs
@@ -18,22 +18,8 @@ pub struct Stats {
 }
 
 impl AddressInfo {
-    // we can something like this here
-    // pub fn get_network(network: &str) -> Network {
-    //         let network_kind = match &USERNETWORK {
-    //         Bitcoin => Network::Bitcoin,
-    //         Testnet => Network::Testnet,
-    //         _ => Network::Testnet,
-    //     };
-    //     return network_kind;
-    // }
     pub async fn get_address_info(address: String) -> Self {
-        let network_kind = match &USERNETWORK {
-            Bitcoin => Network::Bitcoin,
-            Testnet => Network::Testnet,
-            _ => Network::Testnet,
-        };
-        let request_url = match network_kind {
+        let request_url = match *USERNETWORK {
             Network::Bitcoin => {
                 format!(
                     "https://blockstream.info/api/address/{address}",
@@ -72,13 +58,7 @@ pub struct Status {
 }
 
 pub async fn get_transactions(address: String) -> Transactions {
-    let network_kind = match &USERNETWORK {
-        Bitcoin => Network::Bitcoin,
-        Testnet => Network::Testnet,
-        _ => Network::Testnet,
-    };
-
-    let request_url = match network_kind {
+    let request_url = match *USERNETWORK {
         Network::Bitcoin => {
             format!(
                 "https://blockstream.info/api/address/{address}/txs",
@@ -109,12 +89,7 @@ impl Txid {
 }
 
 pub async fn get_last_block_height() -> u64 {
-    let network_kind = match &USERNETWORK {
-        Bitcoin => Network::Bitcoin,
-        Testnet => Network::Testnet,
-        _ => Network::Testnet,
-    };
-    let request_url = match network_kind {
+    let request_url = match *USERNETWORK {
         Network::Bitcoin => "https://blockstream.info/api/blocks/tip/height",
         _ => "https://blockstream.info/testnet/api/blocks/tip/height",
     };
@@ -160,13 +135,7 @@ pub fn get_address_to_pay(bill: BitcreditBill) -> String {
         .unwrap();
     let pub_key_bill = bitcoin::PublicKey::new(public_key_bill);
 
-    let network_kind = match &USERNETWORK {
-        Bitcoin => Network::Bitcoin,
-        Testnet => Network::Testnet,
-        _ => Network::Testnet,
-    };
-
-    bitcoin::Address::p2pkh(pub_key_bill, network_kind).to_string()
+    bitcoin::Address::p2pkh(pub_key_bill, *USERNETWORK).to_string()
 }
 
 pub async fn generate_link_to_pay(address: String, amount: u64, message: String) -> String {

--- a/src/external/bitcoin.rs
+++ b/src/external/bitcoin.rs
@@ -1,9 +1,9 @@
-use crate::{service::bill_service::BitcreditBill};
+use crate::service::bill_service::BitcreditBill;
+use crate::Config;
 use bitcoin::Network;
+use clap::Parser;
 use serde::Deserialize;
 use std::str::FromStr;
-use crate::Config;
-use clap::Parser;
 
 /// Fields documented at https://github.com/Blockstream/esplora/blob/master/API.md#addresses
 #[derive(Deserialize, Debug)]

--- a/src/external/bitcoin.rs
+++ b/src/external/bitcoin.rs
@@ -1,7 +1,6 @@
 use crate::service::bill_service::BitcreditBill;
-use crate::Config;
+use crate::USERNETWORK;
 use bitcoin::Network;
-use clap::Parser;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -19,10 +18,23 @@ pub struct Stats {
 }
 
 impl AddressInfo {
+    
+    // we can something like this here
+    // pub fn get_network(network: &str) -> Network {
+    //         let network_kind = match &USERNETWORK {
+    //         Bitcoin => Network::Bitcoin,
+    //         Testnet => Network::Testnet,
+    //         _ => Network::Testnet,
+    //     };
+    //     return network_kind;
+    // }
     pub async fn get_address_info(address: String) -> Self {
-        let conf = Config::try_parse();
-        let network = conf.expect("Unable to fetch config").bitcoin_network();
-        let request_url = match network {
+        let network_kind = match &USERNETWORK {
+            Bitcoin => Network::Bitcoin,
+            Testnet => Network::Testnet,
+            _ => Network::Testnet,
+        };
+        let request_url = match network_kind {
             Network::Bitcoin => {
                 format!(
                     "https://blockstream.info/api/address/{address}",
@@ -61,9 +73,13 @@ pub struct Status {
 }
 
 pub async fn get_transactions(address: String) -> Transactions {
-    let conf = Config::try_parse();
-    let network = conf.expect("Unable to fetch config").bitcoin_network();
-    let request_url = match network {
+    let network_kind = match &USERNETWORK {
+        Bitcoin => Network::Bitcoin,
+        Testnet => Network::Testnet,
+        _ => Network::Testnet,
+    };
+
+    let request_url = match network_kind {
         Network::Bitcoin => {
             format!(
                 "https://blockstream.info/api/address/{address}/txs",
@@ -94,9 +110,12 @@ impl Txid {
 }
 
 pub async fn get_last_block_height() -> u64 {
-    let conf = Config::try_parse();
-    let network = conf.expect("Unable to fetch config").bitcoin_network();
-    let request_url = match network {
+    let network_kind = match &USERNETWORK {
+        Bitcoin => Network::Bitcoin,
+        Testnet => Network::Testnet,
+        _ => Network::Testnet,
+    };
+    let request_url = match network_kind {
         Network::Bitcoin => "https://blockstream.info/api/blocks/tip/height",
         _ => "https://blockstream.info/testnet/api/blocks/tip/height",
     };
@@ -141,9 +160,14 @@ pub fn get_address_to_pay(bill: BitcreditBill) -> String {
         .combine(&public_key_bill_holder.inner)
         .unwrap();
     let pub_key_bill = bitcoin::PublicKey::new(public_key_bill);
-    let conf = Config::try_parse();
-    let network = conf.expect("Unable to fetch config").bitcoin_network();
-    bitcoin::Address::p2pkh(pub_key_bill, network).to_string()
+
+    let network_kind = match &USERNETWORK {
+        Bitcoin => Network::Bitcoin,
+        Testnet => Network::Testnet,
+        _ => Network::Testnet,
+    };
+
+    bitcoin::Address::p2pkh(pub_key_bill, network_kind).to_string()
 }
 
 pub async fn generate_link_to_pay(address: String, amount: u64, message: String) -> String {

--- a/src/external/bitcoin.rs
+++ b/src/external/bitcoin.rs
@@ -18,7 +18,6 @@ pub struct Stats {
 }
 
 impl AddressInfo {
-    
     // we can something like this here
     // pub fn get_network(network: &str) -> Network {
     //         let network_kind = match &USERNETWORK {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use crate::constants::{
     BILLS_FOLDER_PATH, BILLS_KEYS_FOLDER_PATH, BOOTSTRAP_FOLDER_PATH, QUOTES_MAP_FOLDER_PATH,
 };
 use anyhow::Result;
+use bitcoin::Network;
 use clap::Parser;
 use config::Config;
 use constants::SHUTDOWN_GRACE_PERIOD_MS;
@@ -11,7 +12,8 @@ use service::create_service_context;
 use std::path::Path;
 use std::{env, fs};
 use tokio::spawn;
-
+// #[macro_use]
+// extern crate lazy_static;
 mod bill;
 mod blockchain;
 mod config;
@@ -27,11 +29,22 @@ mod util;
 mod web;
 
 // MAIN
+#[macro_use]
+extern crate lazy_static;
+lazy_static! {
+    pub static ref USERNETWORK: Network = Config::try_parse()
+        .expect("Unable to fetch config")
+        .bitcoin_network();
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     env::set_var("RUST_BACKTRACE", "full");
 
     env_logger::init();
+
+    // You can now use USERNETWORK globally
+    println!("Chosen Network: {:?}", *USERNETWORK);
 
     // Parse command line arguments and env vars with clap
     let conf = Config::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,6 @@ use service::create_service_context;
 use std::path::Path;
 use std::{env, fs};
 use tokio::spawn;
-// #[macro_use]
-// extern crate lazy_static;
 mod bill;
 mod blockchain;
 mod config;

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -5,23 +5,18 @@ use crate::blockchain::{
     self, start_blockchain_for_new_bill, Block, Chain, ChainToReturn, GossipsubEvent,
     GossipsubEventId, OperationCode,
 };
-<<<<<<< HEAD
-use crate::constants::{COMPOUNDING_INTEREST_RATE_ZERO, USEDNET};
-use crate::persistence::file_upload::FileUploadStoreApi;
-=======
 use crate::constants::{
     COMPOUNDING_INTEREST_RATE_ZERO, MAX_FILE_NAME_CHARACTERS, MAX_FILE_SIZE_BYTES,
     VALID_FILE_MIME_TYPES,
 };
->>>>>>> a67ce48 (chore:remove usernet and use config variable for bitcoin network)
 use crate::persistence::identity::IdentityStoreApi;
 use crate::util::get_current_payee_private_key;
-use crate::web::data::File;
-use crate::{dht, external, persistence, util};
+use crate::Config;
 use crate::{dht::Client, persistence::bill::BillStoreApi};
 use async_trait::async_trait;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use chrono::Utc;
+use clap::Parser;
 use log::{error, info};
 use openssl::pkey::Private;
 use openssl::rsa::Rsa;
@@ -29,8 +24,6 @@ use rocket::serde::{Deserialize, Serialize};
 use rocket::{http::Status, response::Responder};
 use std::sync::Arc;
 use thiserror::Error;
-use crate::Config;
-use clap::Parser;
 
 /// Generic result type
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -8,7 +8,6 @@ use crate::{
     web::data::File,
 };
 use async_trait::async_trait;
-use bitcoin::Network;
 use borsh_derive::{self, BorshDeserialize, BorshSerialize};
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -153,12 +152,7 @@ impl CompanyServiceApi for CompanyService {
         proof_of_registration_file_upload_id: Option<String>,
         logo_file_upload_id: Option<String>,
     ) -> Result<CompanyToReturn> {
-        let network_kind = match &USERNETWORK {
-            Bitcoin => Network::Bitcoin,
-            Testnet => Network::Testnet,
-            _ => Network::Testnet,
-        };
-        let (private_key, public_key) = util::create_bitcoin_keypair(network_kind);
+        let (private_key, public_key) = util::create_bitcoin_keypair(*USERNETWORK);
         let id = util::sha256_hash(&public_key.to_bytes());
 
         let company_keys = CompanyKeys {

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -1,20 +1,18 @@
+use super::Result;
+use crate::persistence::company::CompanyStoreApi;
+use crate::USERNETWORK;
 use crate::{
-    constants::USEDNET,
     error,
     persistence::{file_upload::FileUploadStoreApi, identity::IdentityStoreApi, ContactStoreApi},
     util,
     web::data::File,
 };
-use borsh_derive::{self, BorshDeserialize, BorshSerialize};
-use std::sync::Arc;
-
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-
-use crate::persistence::company::CompanyStoreApi;
-
-use super::Result;
+use bitcoin::Network;
+use borsh_derive::{self, BorshDeserialize, BorshSerialize};
 use log::info;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 #[async_trait]
 pub trait CompanyServiceApi: Send + Sync {
@@ -155,7 +153,12 @@ impl CompanyServiceApi for CompanyService {
         proof_of_registration_file_upload_id: Option<String>,
         logo_file_upload_id: Option<String>,
     ) -> Result<CompanyToReturn> {
-        let (private_key, public_key) = util::create_bitcoin_keypair(USEDNET);
+        let network_kind = match &USERNETWORK {
+            Bitcoin => Network::Bitcoin,
+            Testnet => Network::Testnet,
+            _ => Network::Testnet,
+        };
+        let (private_key, public_key) = util::create_bitcoin_keypair(network_kind);
         let id = util::sha256_hash(&public_key.to_bytes());
 
         let company_keys = CompanyKeys {

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -1,14 +1,14 @@
 use super::Result;
+use crate::Config;
 use crate::{dht::Client, persistence::identity::IdentityStoreApi, util};
 use async_trait::async_trait;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
+use clap::Parser;
 use libp2p::identity::Keypair;
 use libp2p::PeerId;
 use openssl::{pkey::Private, rsa::Rsa};
 use rocket::serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use crate::Config;
-use clap::Parser;
 
 #[async_trait]
 pub trait IdentityServiceApi: Send + Sync {
@@ -96,7 +96,7 @@ impl IdentityServiceApi for IdentityService {
             .map_err(|e| super::Error::Cryptography(e.to_string()))?;
 
         let s = bitcoin::secp256k1::Secp256k1::new();
-             let conf = Config::try_parse();
+        let conf = Config::try_parse();
         let network = conf.expect("Unable to fetch config").bitcoin_network();
         let private_key = bitcoin::PrivateKey::new(
             s.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -2,7 +2,6 @@ use super::Result;
 use crate::USERNETWORK;
 use crate::{dht::Client, persistence::identity::IdentityStoreApi, util};
 use async_trait::async_trait;
-use bitcoin::Network;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use libp2p::identity::Keypair;
 use libp2p::PeerId;
@@ -97,16 +96,10 @@ impl IdentityServiceApi for IdentityService {
 
         let s = bitcoin::secp256k1::Secp256k1::new();
 
-        let network_kind = match &USERNETWORK {
-            Bitcoin => Network::Bitcoin,
-            Testnet => Network::Testnet,
-            _ => Network::Testnet,
-        };
-
         let private_key = bitcoin::PrivateKey::new(
             s.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
                 .0,
-            network_kind,
+            *USERNETWORK,
         );
         let public_key = private_key.public_key(&s).to_string();
         let private_key = private_key.to_string();

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -1,14 +1,14 @@
 use super::Result;
+use crate::USERNETWORK;
 use crate::{dht::Client, persistence::identity::IdentityStoreApi, util};
 use async_trait::async_trait;
+use bitcoin::Network;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use libp2p::identity::Keypair;
 use libp2p::PeerId;
 use openssl::{pkey::Private, rsa::Rsa};
 use rocket::serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use crate::USERNETWORK;
-use bitcoin::Network;
 
 #[async_trait]
 pub trait IdentityServiceApi: Send + Sync {
@@ -97,7 +97,7 @@ impl IdentityServiceApi for IdentityService {
 
         let s = bitcoin::secp256k1::Secp256k1::new();
 
-         let network_kind = match &USERNETWORK {
+        let network_kind = match &USERNETWORK {
             Bitcoin => Network::Bitcoin,
             Testnet => Network::Testnet,
             _ => Network::Testnet,

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -1,14 +1,14 @@
 use super::Result;
-use crate::Config;
 use crate::{dht::Client, persistence::identity::IdentityStoreApi, util};
 use async_trait::async_trait;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
-use clap::Parser;
 use libp2p::identity::Keypair;
 use libp2p::PeerId;
 use openssl::{pkey::Private, rsa::Rsa};
 use rocket::serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use crate::USERNETWORK;
+use bitcoin::Network;
 
 #[async_trait]
 pub trait IdentityServiceApi: Send + Sync {
@@ -96,12 +96,17 @@ impl IdentityServiceApi for IdentityService {
             .map_err(|e| super::Error::Cryptography(e.to_string()))?;
 
         let s = bitcoin::secp256k1::Secp256k1::new();
-        let conf = Config::try_parse();
-        let network = conf.expect("Unable to fetch config").bitcoin_network();
+
+         let network_kind = match &USERNETWORK {
+            Bitcoin => Network::Bitcoin,
+            Testnet => Network::Testnet,
+            _ => Network::Testnet,
+        };
+
         let private_key = bitcoin::PrivateKey::new(
             s.generate_keypair(&mut bitcoin::secp256k1::rand::thread_rng())
                 .0,
-            network,
+            network_kind,
         );
         let public_key = private_key.public_key(&s).to_string();
         let private_key = private_key.to_string();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -47,10 +47,5 @@ pub fn get_current_payee_private_key(identity: Identity, bill: BitcreditBill) ->
         .inner
         .add_tweak(&Scalar::from(private_key_bill_holder.inner))
         .unwrap();
-    let network_kind = match &USERNETWORK {
-        Bitcoin => Network::Bitcoin,
-        Testnet => Network::Testnet,
-        _ => Network::Testnet,
-    };
-    bitcoin::PrivateKey::new(privat_key_bill, network_kind).to_string()
+    bitcoin::PrivateKey::new(privat_key_bill, *USERNETWORK).to_string()
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,14 +8,11 @@ use crate::{
 };
 use bitcoin::{secp256k1::Scalar, Network, PrivateKey, PublicKey};
 use crate::Config;
-use crate::{service::bill_service::BitcreditBill, service::identity_service::Identity};
-use bitcoin::secp256k1::Scalar;
 use clap::Parser;
 use openssl::sha::sha256;
 use std::str::FromStr;
 use uuid::Uuid;
 use crate::USERNETWORK;
-use bitcoin::Network;
 
 #[cfg(not(test))]
 pub fn get_uuid_v4() -> Uuid {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,9 +7,15 @@ use crate::{
     constants::USEDNET, service::bill_service::BitcreditBill, service::identity_service::Identity,
 };
 use bitcoin::{secp256k1::Scalar, Network, PrivateKey, PublicKey};
+use crate::Config;
+use crate::{service::bill_service::BitcreditBill, service::identity_service::Identity};
+use bitcoin::secp256k1::Scalar;
+use clap::Parser;
 use openssl::sha::sha256;
 use std::str::FromStr;
 use uuid::Uuid;
+use crate::USERNETWORK;
+use bitcoin::Network;
 
 #[cfg(not(test))]
 pub fn get_uuid_v4() -> Uuid {
@@ -48,6 +54,10 @@ pub fn get_current_payee_private_key(identity: Identity, bill: BitcreditBill) ->
         .inner
         .add_tweak(&Scalar::from(private_key_bill_holder.inner))
         .unwrap();
-
-    bitcoin::PrivateKey::new(privat_key_bill, USEDNET).to_string()
+   let network_kind = match &USERNETWORK {
+        Bitcoin => Network::Bitcoin,
+        Testnet => Network::Testnet,
+        _ => Network::Testnet,
+    };
+    bitcoin::PrivateKey::new(privat_key_bill, network_kind).to_string()
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,12 +3,10 @@ pub mod file;
 pub mod numbers_to_words;
 pub mod rsa;
 pub mod terminal;
-use crate::{
-    constants::USEDNET, service::bill_service::BitcreditBill, service::identity_service::Identity,
-};
 use bitcoin::{secp256k1::Scalar, Network, PrivateKey, PublicKey};
-use crate::Config;
-use clap::Parser;
+use crate::{service::bill_service::BitcreditBill, service::identity_service::Identity};
+use bitcoin::secp256k1::Scalar;
+use bitcoin::Network;
 use openssl::sha::sha256;
 use std::str::FromStr;
 use uuid::Uuid;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -3,14 +3,12 @@ pub mod file;
 pub mod numbers_to_words;
 pub mod rsa;
 pub mod terminal;
-use bitcoin::{secp256k1::Scalar, Network, PrivateKey, PublicKey};
+use crate::USERNETWORK;
 use crate::{service::bill_service::BitcreditBill, service::identity_service::Identity};
-use bitcoin::secp256k1::Scalar;
-use bitcoin::Network;
+use bitcoin::{secp256k1::Scalar, Network, PrivateKey, PublicKey};
 use openssl::sha::sha256;
 use std::str::FromStr;
 use uuid::Uuid;
-use crate::USERNETWORK;
 
 #[cfg(not(test))]
 pub fn get_uuid_v4() -> Uuid {
@@ -49,7 +47,7 @@ pub fn get_current_payee_private_key(identity: Identity, bill: BitcreditBill) ->
         .inner
         .add_tweak(&Scalar::from(private_key_bill_holder.inner))
         .unwrap();
-   let network_kind = match &USERNETWORK {
+    let network_kind = match &USERNETWORK {
         Bitcoin => Network::Bitcoin,
         Testnet => Network::Testnet,
         _ => Network::Testnet,


### PR DESCRIPTION
PR that closes issue: #203 

added a new config variable called environment, then create a function that return bitcoin depending on the current environment i.e development or production. 

swap the current constant network value with  network value return from the bitcoin_network function. 