### PR TITLE
139 company identity dht impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "hex",
  "hf",
  "infer",
+ "lazy_static",
  "lettre",
  "libp2p",
  "log",

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -141,6 +141,8 @@ pub enum GossipsubEventId {
     Block,
     Chain,
     CommandGetChain,
+    AddSignatoryFromCompany,
+    RemoveSignatoryFromCompany,
 }
 
 #[cfg(test)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,10 +2,15 @@ use std::net::Ipv4Addr;
 
 // General
 pub const BILLS_PREFIX: &str = "BILLS";
-pub const INFO_PREFIX: &str = "INFO";
 pub const BILL_PREFIX: &str = "BILL";
 pub const BILL_ATTACHMENT_PREFIX: &str = "BILLATT";
 pub const KEY_PREFIX: &str = "KEY";
+pub const COMPANIES_PREFIX: &str = "COMPANIES";
+pub const COMPANY_PREFIX: &str = "COMPANY";
+pub const COMPANY_KEY_PREFIX: &str = "COMPANYKEY";
+pub const COMPANY_LOGO_PREFIX: &str = "COMPANYLOGO";
+pub const COMPANY_PROOF_PREFIX: &str = "COMPANYPROOF";
+pub const IDENTITY_PREFIX: &str = "IDENTITY";
 pub const SHUTDOWN_GRACE_PERIOD_MS: u64 = 1500;
 
 // Validation

--- a/src/dht/behaviour.rs
+++ b/src/dht/behaviour.rs
@@ -465,6 +465,10 @@ mod test {
         assert!(parse_inbound_file_request("nodeid_BILL_TEST").is_ok());
         assert!(parse_inbound_file_request("nodeid_KEY_TEST").is_ok());
         assert!(parse_inbound_file_request("nodeid_BILLATT_TEST_TEST").is_ok());
+        assert!(parse_inbound_file_request("nodeid_COMPANY_TEST").is_ok());
+        assert!(parse_inbound_file_request("nodeid_COMPANYKEY_TEST").is_ok());
+        assert!(parse_inbound_file_request("nodeid_COMPANYLOGO_TEST_TEST").is_ok());
+        assert!(parse_inbound_file_request("nodeid_COMPANYPROOF_TEST_TEST").is_ok());
     }
 
     #[test]
@@ -535,6 +539,100 @@ mod test {
                 node_id: "nodeid".to_string(),
                 bill_name: "TEST".to_string(),
                 file_name: "FILE".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_inbound_file_request_content_company_data() {
+        assert_eq!(
+            parse_inbound_file_request("nodeid_COMPANY_TEST").unwrap(),
+            ParsedInboundFileRequest::CompanyData(CompanyDataRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn file_request_parse_inbound_file_request_content_company_data() {
+        assert_eq!(
+            parse_inbound_file_request(&file_request_for_company_data("nodeid", "TEST")).unwrap(),
+            ParsedInboundFileRequest::CompanyData(CompanyDataRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_inbound_file_request_content_company_keys() {
+        assert_eq!(
+            parse_inbound_file_request("nodeid_COMPANYKEY_TEST").unwrap(),
+            ParsedInboundFileRequest::CompanyKeys(CompanyKeysRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn file_request_parse_inbound_file_request_content_company_keys() {
+        assert_eq!(
+            parse_inbound_file_request(&file_request_for_company_keys("nodeid", "TEST")).unwrap(),
+            ParsedInboundFileRequest::CompanyKeys(CompanyKeysRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_inbound_file_request_content_company_logo() {
+        assert_eq!(
+            parse_inbound_file_request("nodeid_COMPANYLOGO_TEST_TEST").unwrap(),
+            ParsedInboundFileRequest::CompanyLogo(CompanyLogoRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+                file_name: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn file_request_parse_inbound_file_request_content_company_logo() {
+        assert_eq!(
+            parse_inbound_file_request(&file_request_for_company_logo("nodeid", "TEST", "TEST"))
+                .unwrap(),
+            ParsedInboundFileRequest::CompanyLogo(CompanyLogoRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+                file_name: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_inbound_file_request_content_company_proof() {
+        assert_eq!(
+            parse_inbound_file_request("nodeid_COMPANYPROOF_TEST_TEST").unwrap(),
+            ParsedInboundFileRequest::CompanyProof(CompanyProofRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+                file_name: "TEST".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn file_request_parse_inbound_file_request_content_company_proof() {
+        assert_eq!(
+            parse_inbound_file_request(&file_request_for_company_proof("nodeid", "TEST", "TEST"))
+                .unwrap(),
+            ParsedInboundFileRequest::CompanyProof(CompanyProofRequest {
+                node_id: "nodeid".to_string(),
+                company_id: "TEST".to_string(),
+                file_name: "TEST".to_string(),
             })
         );
     }

--- a/src/dht/behaviour.rs
+++ b/src/dht/behaviour.rs
@@ -187,6 +187,17 @@ pub enum Event {
         request: String,
         channel: ResponseChannel<FileResponse>,
     },
+    CompanyUpdate {
+        event: CompanyEvent,
+        company_id: String,
+        signatory: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum CompanyEvent {
+    AddSignatory,
+    RemoveSignatory,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/dht/behaviour.rs
+++ b/src/dht/behaviour.rs
@@ -141,11 +141,11 @@ impl From<dcutr::Event> for ComposedEvent {
 #[derive(Debug)]
 pub enum Command {
     StartProviding {
-        file_name: String,
+        entry: String,
         sender: oneshot::Sender<()>,
     },
     GetProviders {
-        file_name: String,
+        entry: String,
         sender: oneshot::Sender<HashSet<PeerId>>,
     },
     PutRecord {

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -1,18 +1,26 @@
 use super::behaviour::{
     file_request_for_bill, file_request_for_bill_attachment, file_request_for_bill_keys,
-    parse_inbound_file_request, BillAttachmentFileRequest, BillFileRequest, BillKeysFileRequest,
-    Command, Event, FileResponse, ParsedInboundFileRequest,
+    file_request_for_company_data, file_request_for_company_keys, file_request_for_company_logo,
+    file_request_for_company_proof, parse_inbound_file_request, BillAttachmentFileRequest,
+    BillFileRequest, BillKeysFileRequest, Command, CompanyDataRequest, CompanyKeysRequest,
+    CompanyLogoRequest, CompanyProofRequest, Event, FileResponse, ParsedInboundFileRequest,
 };
 use super::Result;
 use crate::blockchain::{Chain, GossipsubEvent, GossipsubEventId};
-use crate::constants::{BILLS_PREFIX, INFO_PREFIX};
+use crate::constants::{
+    BILLS_PREFIX, BILL_PREFIX, COMPANIES_PREFIX, COMPANY_PREFIX, IDENTITY_PREFIX,
+};
 use crate::persistence::bill::BillStoreApi;
-use crate::persistence::company::CompanyStoreApi;
+use crate::persistence::company::{
+    company_from_bytes, company_keys_from_bytes, company_keys_to_bytes, company_to_bytes,
+    CompanyStoreApi,
+};
 use crate::persistence::identity::IdentityStoreApi;
 use crate::service::company_service::{Company, CompanyKeys, CompanyPublicData};
 use crate::service::contact_service::IdentityPublicData;
 use crate::util;
 use crate::util::rsa::{decrypt_bytes_with_private_key, encrypt_bytes_with_public_key};
+use borsh::{from_slice, to_vec};
 use future::try_join_all;
 use futures::channel::mpsc::Receiver;
 use futures::channel::{mpsc, oneshot};
@@ -21,7 +29,7 @@ use libp2p::kad::record::Record;
 use libp2p::request_response::ResponseChannel;
 use libp2p::PeerId;
 use log::{error, info};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -71,16 +79,382 @@ impl Client {
     // Company-related logic ---------------------------------------
     // --------------------------------------------------------------
 
-    pub async fn put_companies_public_data_in_dht(&mut self) -> Result<()> {
+    fn company_key(&self, company_id: &str) -> String {
+        format!("{COMPANY_PREFIX}{company_id}")
+    }
+
+    fn node_request_for_companies(&self, node_id: &str) -> String {
+        format!("{COMPANIES_PREFIX}{node_id}")
+    }
+
+    /// Gets the list of companies from the network for the local node and gets the companies that
+    /// aren't locally available from the network and start providing them and subscribing to them
+    pub async fn check_new_companies(&mut self) -> Result<()> {
+        log::info!("Checking for new companies...");
+        let local_peer_id = self.identity_store.get_peer_id().await?;
+        let node_request = self.node_request_for_companies(&local_peer_id.to_string());
+        let companies_for_node = self.get_record(node_request.clone()).await?.value;
+        if companies_for_node.is_empty() {
+            return Ok(());
+        }
+        let companies: Vec<String> = from_slice(&companies_for_node)?;
+        for company in companies {
+            if self.company_store.exists(&company).await {
+                continue;
+            }
+            self.get_company_data_from_the_network(&company, &local_peer_id)
+                .await?;
+            self.start_providing_company(&company).await?;
+            self.subscribe_to_company_topic(&company).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_company_data_from_the_network(
+        &mut self,
+        company_id: &str,
+        local_peer_id: &PeerId,
+    ) -> Result<()> {
+        let mut providers = self.get_company_providers(company_id).await?;
+        providers.remove(local_peer_id);
+        if providers.is_empty() {
+            error!("Get Company Files: No providers found for {company_id}");
+            return Ok(());
+        }
+        let company = self
+            .request_company_data(company_id, local_peer_id, &providers)
+            .await?;
+
+        let company_keys = self
+            .request_company_keys(company_id, local_peer_id, &providers)
+            .await?;
+
+        let mut logo_file: Option<Vec<u8>> = None;
+        if let Some(ref logo) = company.logo_file {
+            let file_request =
+                file_request_for_company_logo(&local_peer_id.to_string(), company_id, &logo.name);
+            logo_file = Some(
+                self.request_company_file(company_id, file_request, &providers)
+                    .await?,
+            );
+        }
+        let mut proof_file: Option<Vec<u8>> = None;
+        if let Some(ref proof) = company.proof_of_registration_file {
+            let file_request =
+                file_request_for_company_proof(&local_peer_id.to_string(), company_id, &proof.name);
+            proof_file = Some(
+                self.request_company_file(company_id, file_request, &providers)
+                    .await?,
+            );
+        }
+
+        self.company_store.insert(company_id, &company).await?;
+        self.company_store
+            .save_key_pair(company_id, &company_keys)
+            .await?;
+
+        if logo_file.is_some() || proof_file.is_some() {
+            let public_key = self.identity_store.get().await?.private_key_pem;
+            if let Some(logo) = logo_file {
+                let encrypted_bytes = encrypt_bytes_with_public_key(&logo, &public_key);
+                if let Some(ref file) = company.logo_file {
+                    self.company_store
+                        .save_attached_file(&encrypted_bytes, company_id, &file.name)
+                        .await?;
+                }
+            }
+
+            if let Some(proof) = proof_file {
+                let encrypted_bytes = encrypt_bytes_with_public_key(&proof, &public_key);
+                if let Some(ref file) = company.proof_of_registration_file {
+                    self.company_store
+                        .save_attached_file(&encrypted_bytes, company_id, &file.name)
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn request_company_data(
+        &mut self,
+        company_id: &str,
+        local_peer_id: &PeerId,
+        providers: &HashSet<PeerId>,
+    ) -> Result<Company> {
+        let requests = providers.iter().map(|peer| {
+            let mut network_client = self.clone();
+            let file_request =
+                file_request_for_company_data(&local_peer_id.to_string(), company_id);
+            async move {
+                network_client
+                    .request_file(peer.to_owned(), file_request)
+                    .await
+            }
+            .boxed()
+        });
+
+        match futures::future::select_ok(requests).await {
+            Err(e) => Err(super::Error::NoProviders(format!(
+                "Get Company Data: None of the providers returned the file for {company_id}: {e}",
+            ))),
+            Ok(file_content) => {
+                let company = company_from_bytes(&file_content.0)?;
+                Ok(company)
+            }
+        }
+    }
+
+    async fn request_company_keys(
+        &mut self,
+        company_id: &str,
+        local_peer_id: &PeerId,
+        providers: &HashSet<PeerId>,
+    ) -> Result<CompanyKeys> {
+        let requests = providers.iter().map(|peer| {
+            let mut network_client = self.clone();
+            let file_request =
+                file_request_for_company_keys(&local_peer_id.to_string(), company_id);
+            async move {
+                network_client
+                    .request_file(peer.to_owned(), file_request)
+                    .await
+            }
+            .boxed()
+        });
+
+        match futures::future::select_ok(requests).await {
+            Err(e) => Err(super::Error::NoProviders(format!(
+                "Get Company Keys: None of the providers returned the file for {company_id}: {e}",
+            ))),
+            Ok(file_content) => {
+                let encrypted_bytes = file_content.0;
+                let identity = self.identity_store.get().await?;
+                let decrypted_bytes =
+                    decrypt_bytes_with_private_key(&encrypted_bytes, identity.private_key_pem);
+                let company_keys = company_keys_from_bytes(&decrypted_bytes)?;
+                Ok(company_keys)
+            }
+        }
+    }
+
+    async fn request_company_file(
+        &mut self,
+        company_id: &str,
+        file_request: String,
+        providers: &HashSet<PeerId>,
+    ) -> Result<Vec<u8>> {
+        let requests = providers.iter().map(|peer| {
+            let mut network_client = self.clone();
+            let file_request_clone = file_request.clone();
+            async move {
+                network_client
+                    .request_file(peer.to_owned(), file_request_clone)
+                    .await
+            }
+            .boxed()
+        });
+
+        match futures::future::select_ok(requests).await {
+            Err(e) => Err(super::Error::NoProviders(format!(
+                "Get Company File: None of the providers returned the file for {company_id}: {e}",
+            ))),
+            Ok(file_content) => {
+                let encrypted_bytes = file_content.0;
+                let identity = self.identity_store.get().await?;
+                let decrypted_bytes =
+                    decrypt_bytes_with_private_key(&encrypted_bytes, identity.private_key_pem);
+                let encrypted_bytes =
+                    encrypt_bytes_with_public_key(&decrypted_bytes, &identity.public_key_pem);
+                Ok(encrypted_bytes)
+            }
+        }
+    }
+
+    /// Subscribes to all locally available companies
+    pub async fn subscribe_to_all_companies_topics(&mut self) -> Result<()> {
         let companies = self.company_store.get_all().await?;
+
+        if !companies.is_empty() {
+            let tasks = companies.into_iter().map(|(id, (_, _))| {
+                let mut self_clone = self.clone();
+                async move { self_clone.subscribe_to_bill_topic(&id).await }
+            });
+
+            try_join_all(tasks).await?;
+        }
+        Ok(())
+    }
+
+    /// Starts providing all locally available companies
+    pub async fn start_providing_companies(&mut self) -> Result<()> {
+        let companies = self.company_store.get_all().await?;
+
+        if !companies.is_empty() {
+            let tasks = companies.into_iter().map(|(id, (_, _))| {
+                let mut self_clone = self.clone();
+                async move { self_clone.start_providing_company(&id).await }
+            });
+
+            try_join_all(tasks).await?;
+        }
+        Ok(())
+    }
+
+    /// Puts all signatories of every local company to the record of the respective company in the DHT
+    pub async fn put_companies_for_signatories(&mut self) -> Result<()> {
+        log::info!("Putting signatories for local companies in the DHT");
+        let companies = self.company_store.get_all().await?;
+
+        // for each signatory, make one set_record with a list of the companies
+        if !companies.is_empty() {
+            // collect companies for each unique signatory
+            let mut signatory_companies_map: HashMap<String, Vec<String>> = HashMap::new();
+            for (company_id, (company, _)) in companies {
+                for signatory in company.signatories {
+                    signatory_companies_map
+                        .entry(signatory.clone())
+                        .or_default()
+                        .push(company_id.clone());
+                }
+            }
+
+            // for each signatory, set the collected companies on the DHT
+            let tasks = signatory_companies_map
+                .into_iter()
+                .map(|(signatory, company_ids)| {
+                    let mut self_clone = self.clone();
+                    async move {
+                        self_clone
+                            .add_companies_to_dht_for_node(company_ids, &signatory)
+                            .await
+                    }
+                });
+
+            try_join_all(tasks).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Adds the given list of companies to the DHT for the node_id, if the data from the DHT is
+    /// empty, or invalid, we just set the given list, otherwise we merge the unique elements of both
+    pub async fn add_companies_to_dht_for_node(
+        &mut self,
+        company_ids: Vec<String>,
+        node_id: &str,
+    ) -> Result<()> {
+        let node_request = self.node_request_for_companies(node_id);
+        let companies_for_node = self.get_record(node_request.clone()).await?.value;
+        if companies_for_node.is_empty() {
+            self.put_record(node_request, to_vec(&company_ids)?).await?;
+        } else {
+            match from_slice::<Vec<String>>(&companies_for_node) {
+                Ok(dht_record) => {
+                    let mut unique_elements: HashSet<String> = HashSet::new();
+                    unique_elements.extend(dht_record.clone().into_iter());
+                    unique_elements.extend(company_ids.into_iter());
+                    let result: Vec<String> = unique_elements.into_iter().collect();
+
+                    if !dht_record.eq(&result) {
+                        self.put_record(node_request.clone(), to_vec(&result)?)
+                            .await?;
+                    }
+                }
+                Err(e) => {
+                    error!("Could not parse company data in dht for {node_id}: {e}");
+                    self.put_record(node_request.clone(), to_vec(&company_ids)?)
+                        .await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Removes the given company from the list of companies for the given node - if the data is empty,
+    /// or invalid, we don't do anything. Otherwise, we remove the given company id from the DHT value,
+    /// if it contains it
+    pub async fn remove_company_from_dht_for_node(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+    ) -> Result<()> {
+        let node_request = self.node_request_for_companies(node_id);
+        let companies_for_node = self.get_record(node_request.clone()).await?.value;
+        if !companies_for_node.is_empty() {
+            match from_slice::<Vec<String>>(&companies_for_node) {
+                Ok(dht_record) => {
+                    let mut record_for_saving_in_dht = dht_record.clone();
+                    record_for_saving_in_dht.retain(|item| item != company_id);
+
+                    if !dht_record.eq(&record_for_saving_in_dht) {
+                        self.put_record(node_request.clone(), to_vec(&record_for_saving_in_dht)?)
+                            .await?;
+                    }
+                }
+                Err(e) => {
+                    error!("Could not parse company data in dht for {node_id} when trying to remove company {company_id}: {e}");
+                }
+            }
+        }
+
+        Ok(())
+    }
+    /// Adds the given company to the list of companies for the given node - if the data is empty,
+    /// or invalid, we just push our local data. Otherwise, we add the given company id to the DHT,
+    /// if it doesn't already contain it
+    pub async fn add_company_to_dht_for_node(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+    ) -> Result<()> {
+        let node_request = self.node_request_for_companies(node_id);
+        let mut record_for_saving_in_dht: Vec<String> = vec![];
+        let companies_for_node = self.get_record(node_request.clone()).await?.value;
+        if companies_for_node.is_empty() {
+            record_for_saving_in_dht.push(company_id.to_owned());
+            self.put_record(node_request, to_vec(&record_for_saving_in_dht)?)
+                .await?;
+        } else {
+            match from_slice::<Vec<String>>(&companies_for_node) {
+                Ok(dht_record) => {
+                    record_for_saving_in_dht = dht_record.clone();
+                    if !record_for_saving_in_dht.contains(&company_id.to_string()) {
+                        record_for_saving_in_dht.push(company_id.to_owned());
+                    }
+                    if !dht_record.eq(&record_for_saving_in_dht) {
+                        self.put_record(node_request.clone(), to_vec(&record_for_saving_in_dht)?)
+                            .await?;
+                    }
+                }
+                Err(e) => {
+                    error!("Could not parse company data in dht for {node_id}: {e}");
+                    self.put_record(node_request.clone(), to_vec(&vec![company_id.to_owned()])?)
+                        .await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Puts the public data of all local companies in the DHT
+    pub async fn put_companies_public_data_in_dht(&mut self) -> Result<()> {
         log::info!("Putting local company public data in the DHT");
+        let companies = self.company_store.get_all().await?;
 
         if !companies.is_empty() {
             let tasks = companies.into_iter().map(|(id, (company, company_keys))| {
                 let mut self_clone = self.clone();
                 async move {
                     self_clone
-                        .put_company_public_data_in_dht((id, (company, company_keys)))
+                        .put_company_public_data_in_dht(CompanyPublicData::from_all(
+                            id.clone(),
+                            company,
+                            company_keys,
+                        ))
                         .await
                 }
             });
@@ -91,30 +465,59 @@ impl Client {
         Ok(())
     }
 
-    async fn put_company_public_data_in_dht(
+    /// Puts the public data of company in the DHT
+    pub async fn put_company_public_data_in_dht(
         &mut self,
-        company_data: (String, (Company, CompanyKeys)),
+        local_public_data: CompanyPublicData,
     ) -> Result<()> {
-        let id = company_data.0;
-        let local_public_data =
-            CompanyPublicData::from(id.clone(), company_data.1 .0, company_data.1 .1);
-        let local_json = serde_json::to_string(&local_public_data)?;
+        let key = self.company_key(&local_public_data.id);
+        let local_json = serde_json::to_string(&local_public_data)?.into_bytes();
 
-        let dht_record = self.get_record(id.clone()).await?.value;
+        let dht_record = self.get_record(key.clone()).await?.value;
         if dht_record.is_empty() {
-            self.put_record(id.clone(), local_json).await?;
+            self.put_record(key, local_json).await?;
         } else {
-            let dht_public_data: CompanyPublicData = serde_json::from_slice(&dht_record)?;
-            if !dht_public_data.eq(&local_public_data) {
-                self.put_record(id.clone(), local_json).await?;
+            match serde_json::from_slice::<CompanyPublicData>(&dht_record) {
+                Err(e) => {
+                    error!(
+                        "Could not parse public data in dht for {}: {e}",
+                        &local_public_data.id
+                    );
+                    self.put_record(key.clone(), local_json).await?;
+                }
+                Ok(dht_public_data) => {
+                    if !dht_public_data.eq(&local_public_data) {
+                        self.put_record(key.clone(), local_json).await?;
+                    }
+                }
             }
         }
         Ok(())
     }
 
+    /// Queries the DHT for the public company data for the given company id
+    #[allow(dead_code)]
+    pub async fn get_company_public_data_from_dht(
+        &mut self,
+        company_id: &str,
+    ) -> Result<Option<CompanyPublicData>> {
+        let key = self.company_key(company_id);
+        let current_info = self.get_record(key.clone()).await?.value;
+        if current_info.is_empty() {
+            return Ok(None);
+        }
+        let company_public_data: CompanyPublicData = serde_json::from_slice(&current_info)?;
+
+        Ok(Some(company_public_data))
+    }
+
     // --------------------------------------------------------------
     // Identity-related logic ---------------------------------------
     // --------------------------------------------------------------
+
+    fn identity_key(&self, peer_id: &str) -> String {
+        format!("{IDENTITY_PREFIX}{peer_id}")
+    }
 
     /// Adds the local identity's public data into the DHT
     pub async fn put_identity_public_data_in_dht(&mut self) -> Result<()> {
@@ -125,7 +528,7 @@ impl Client {
                 identity.peer_id.to_string().clone(),
             );
 
-            let key = format!("{}{}", INFO_PREFIX, &identity_data.peer_id);
+            let key = self.identity_key(&identity_data.peer_id);
             let current_info = self.get_record(key.clone()).await?.value;
             let mut current_info_string = String::new();
             if !current_info.is_empty() {
@@ -133,7 +536,7 @@ impl Client {
             }
             let value = serde_json::to_string(&identity_data)?;
             if !current_info_string.eq(&value) {
-                self.put_record(key, value).await?;
+                self.put_record(key, value.into_bytes()).await?;
             }
         }
         Ok(())
@@ -144,7 +547,7 @@ impl Client {
         &mut self,
         peer_id: String,
     ) -> Result<IdentityPublicData> {
-        let key = format!("{}{}", INFO_PREFIX, &peer_id);
+        let key = self.identity_key(&peer_id);
         let current_info = self.get_record(key.clone()).await?.value;
         let mut identity_public_data: IdentityPublicData = IdentityPublicData::new_empty();
         if !current_info.is_empty() {
@@ -159,40 +562,46 @@ impl Client {
     // Bill-related logic --------------------------------------
     // ---------------------------------------------------------
 
+    fn bill_key(&self, bill_name: &str) -> String {
+        format!("{BILL_PREFIX}{bill_name}")
+    }
+
+    fn node_request_for_bills(&self, node_id: &str) -> String {
+        format!("{BILLS_PREFIX}{node_id}")
+    }
+
     /// Checks the bill record for the local node, adding missing bills and starts providing them, if necessary
     pub async fn update_bills_table(&mut self, node_id: String) -> Result<()> {
-        let node_request = BILLS_PREFIX.to_string() + &node_id;
+        let node_request = self.node_request_for_bills(&node_id);
+
         let list_bills_for_node = self.get_record(node_request.clone()).await?;
         let value = list_bills_for_node.value;
 
         if !value.is_empty() {
-            let record_in_dht = std::str::from_utf8(&value)?.to_string();
-            let mut new_record: String = record_in_dht.clone();
+            let record_in_dht: Vec<String> = from_slice(&value)?;
+            let mut new_record = record_in_dht.clone();
 
             let bill_names = self.bill_store.get_bill_names().await?;
             for bill_name in bill_names {
                 if !record_in_dht.contains(&bill_name) {
-                    new_record += (",".to_string() + &bill_name.clone()).as_str();
-                    self.start_providing(bill_name.clone()).await?;
+                    new_record.push(bill_name.clone());
+                    self.start_providing_bill(&bill_name).await?;
                 }
             }
             if !record_in_dht.eq(&new_record) {
-                self.put_record(node_request.clone(), new_record).await?;
+                self.put_record(node_request.clone(), to_vec(&new_record)?)
+                    .await?;
             }
         } else {
-            let mut new_record = String::new();
             let bill_names = self.bill_store.get_bill_names().await?;
+            let mut new_record = Vec::with_capacity(bill_names.len());
             for bill_name in bill_names {
-                if new_record.is_empty() {
-                    new_record = bill_name.clone();
-                    self.start_providing(bill_name.clone()).await?;
-                } else {
-                    new_record += (",".to_string() + &bill_name.clone()).as_str();
-                    self.start_providing(bill_name.clone()).await?;
-                }
+                new_record.push(bill_name.clone());
+                self.start_providing_bill(&bill_name).await?;
             }
             if !new_record.is_empty() {
-                self.put_record(node_request.clone(), new_record).await?;
+                self.put_record(node_request.clone(), to_vec(&new_record)?)
+                    .await?;
             }
         }
         Ok(())
@@ -202,69 +611,62 @@ impl Client {
     pub async fn start_providing_bills(&mut self) -> Result<()> {
         let bills = self.bill_store.get_bill_names().await?;
         for bill in bills {
-            self.start_providing(bill).await?;
+            self.start_providing_bill(&bill).await?;
         }
         Ok(())
     }
 
-    /// Adds the given bill for the given node id
+    /// Adds the given bill for the given node id - if the data is empty, or invalid, we just push
+    /// our data on the DHT, otherwise we check, if we have data the DHT doesn't have and add that
     pub async fn add_bill_to_dht_for_node(&mut self, bill_name: &str, node_id: &str) -> Result<()> {
-        let node_request = BILLS_PREFIX.to_string() + node_id;
-        let mut record_for_saving_in_dht;
-        let list_bills_for_node = self.get_record(node_request.clone()).await?;
-        let value = list_bills_for_node.value;
-        if !value.is_empty() {
-            record_for_saving_in_dht = std::str::from_utf8(&value)?.to_string();
-            if !record_for_saving_in_dht.contains(bill_name) {
-                record_for_saving_in_dht = record_for_saving_in_dht.to_string() + "," + bill_name;
+        let node_request = self.node_request_for_bills(node_id);
+        let mut record_for_saving_in_dht: Vec<String> = vec![];
+        let list_bills_for_node = self.get_record(node_request.clone()).await?.value;
+        if !list_bills_for_node.is_empty() {
+            match from_slice::<Vec<String>>(&list_bills_for_node) {
+                Ok(dht_record) => {
+                    record_for_saving_in_dht = dht_record.clone();
+                    if !record_for_saving_in_dht.contains(&bill_name.to_string()) {
+                        record_for_saving_in_dht.push(bill_name.to_owned());
+                    }
+                    if !dht_record.eq(&record_for_saving_in_dht) {
+                        self.put_record(node_request.clone(), to_vec(&record_for_saving_in_dht)?)
+                            .await?;
+                    }
+                }
+                Err(e) => {
+                    error!("Could not parse bill data in dht for {}: {e}", &bill_name);
+                    self.put_record(node_request.clone(), to_vec(&vec![bill_name.to_owned()])?)
+                        .await?;
+                }
             }
         } else {
-            record_for_saving_in_dht = bill_name.to_owned();
-        }
-
-        if !std::str::from_utf8(&value)?
-            .to_string()
-            .eq(&record_for_saving_in_dht)
-        {
-            self.put_record(node_request.clone(), record_for_saving_in_dht.to_string())
+            record_for_saving_in_dht.push(bill_name.to_owned());
+            self.put_record(node_request.clone(), to_vec(&record_for_saving_in_dht)?)
                 .await?;
         }
+
         Ok(())
     }
 
     /// Checks the DHT for new bills, fetching the bill data, keys and files for them
     pub async fn check_new_bills(&mut self, node_id: String) -> Result<()> {
-        let node_request = BILLS_PREFIX.to_string() + &node_id;
+        let node_request = self.node_request_for_bills(&node_id);
         let list_bills_for_node = self.get_record(node_request.clone()).await?;
         let value = list_bills_for_node.value;
 
         if !value.is_empty() {
-            let record_for_saving_in_dht = std::str::from_utf8(&value)?.to_string();
-            let bills = record_for_saving_in_dht.split(',');
+            let bills: Vec<String> = from_slice(&value)?;
             for bill_id in bills {
-                if !self.bill_store.bill_exists(bill_id).await {
-                    let bill_bytes = self.get_bill(bill_id).await?;
-                    self.bill_store
-                        .write_bill_to_file(bill_id, &bill_bytes)
-                        .await?;
+                if !self.bill_store.bill_exists(&bill_id).await {
+                    self.get_bill(&bill_id).await?;
 
-                    let key_bytes = self.get_key(bill_id).await?;
-                    let pr_key = self
-                        .identity_store
-                        .get_full()
-                        .await?
-                        .identity
-                        .private_key_pem;
+                    self.get_key(&bill_id).await?;
 
-                    let key_bytes_decrypted = decrypt_bytes_with_private_key(&key_bytes, pr_key);
-                    self.bill_store
-                        .write_bill_keys_to_file_as_bytes(bill_id, &key_bytes_decrypted)
-                        .await?;
-
-                    if let Ok(chain) = self.bill_store.read_bill_chain_from_file(bill_id).await {
+                    if let Ok(chain) = self.bill_store.read_bill_chain_from_file(&bill_id).await {
                         let bill = chain.get_first_version_bill();
                         for file in bill.files {
-                            if let Err(e) = self.get_bill_attachment(bill_id, &file.name).await {
+                            if let Err(e) = self.get_bill_attachment(&bill_id, &file.name).await {
                                 error!("Could not get bill attachment with file name {} for bill {bill_id}: {e}", file.name);
                             }
                         }
@@ -281,15 +683,14 @@ impl Client {
         Ok(())
     }
 
-    /// Requests the data file for the given bill
-    pub async fn get_bill(&mut self, name: &str) -> Result<Vec<u8>> {
+    /// Requests the data file for the given bill, saving it locally
+    pub async fn get_bill(&mut self, name: &str) -> Result<()> {
         let local_peer_id = self.identity_store.get_peer_id().await?;
-        let mut providers = self.get_providers(name.to_owned()).await?;
+        let mut providers = self.get_bill_providers(name).await?;
         providers.remove(&local_peer_id);
         if providers.is_empty() {
-            return Err(super::Error::NoProviders(format!(
-                "Get Bill: No providers found for {name}",
-            )));
+            error!("Get Bill: No providers found for {name}");
+            return Ok(());
         }
         let requests = providers.into_iter().map(|peer| {
             let mut network_client = self.clone();
@@ -302,7 +703,11 @@ impl Client {
             Err(e) => Err(super::Error::NoProviders(format!(
                 "Get Bill: None of the providers returned the file for {name}: {e}",
             ))),
-            Ok(file_content) => Ok(file_content.0),
+            Ok(file_content) => {
+                let bytes = file_content.0;
+                self.bill_store.write_bill_to_file(name, &bytes).await?;
+                Ok(())
+            }
         }
     }
 
@@ -323,12 +728,11 @@ impl Client {
         };
 
         let local_peer_id = self.identity_store.get_peer_id().await?;
-        let mut providers = self.get_providers(bill_name.to_owned()).await?;
+        let mut providers = self.get_bill_providers(bill_name).await?;
         providers.remove(&local_peer_id);
         if providers.is_empty() {
-            return Err(super::Error::NoProviders(format!(
-                "Get Bill Attachment: No providers found for {bill_name}",
-            )));
+            error!("Get Bill Attachment: No providers found for {bill_name}");
+            return Ok(());
         }
 
         let requests = providers.into_iter().map(|peer_id| {
@@ -375,15 +779,14 @@ impl Client {
         }
     }
 
-    /// Requests the keys file for the given bill
-    pub async fn get_key(&mut self, name: &str) -> Result<Vec<u8>> {
+    /// Requests the keys file for the given bill, decrypting it and saving it locally
+    pub async fn get_key(&mut self, name: &str) -> Result<()> {
         let local_peer_id = self.identity_store.get_peer_id().await?;
-        let mut providers = self.get_providers(name.to_owned()).await?;
+        let mut providers = self.get_bill_providers(name).await?;
         providers.remove(&local_peer_id);
         if providers.is_empty() {
-            return Err(super::Error::NoProviders(format!(
-                "Get Bill Keys: No providers found for {name}",
-            )));
+            error!("Get Bill Attachment: No providers found for {name}");
+            return Ok(());
         }
         let requests = providers.into_iter().map(|peer| {
             let mut network_client = self.clone();
@@ -396,7 +799,21 @@ impl Client {
             Err(e) => Err(super::Error::NoFileFromProviders(format!(
                 "Get Bill Keys: None of the providers returned the file for {name}: {e}"
             ))),
-            Ok(file_content) => Ok(file_content.0),
+            Ok(file_content) => {
+                let bytes = file_content.0;
+                let pr_key = self
+                    .identity_store
+                    .get_full()
+                    .await?
+                    .identity
+                    .private_key_pem;
+                let key_bytes_decrypted = decrypt_bytes_with_private_key(&bytes, pr_key);
+
+                self.bill_store
+                    .write_bill_keys_to_file_as_bytes(name, &key_bytes_decrypted)
+                    .await?;
+                Ok(())
+            }
         }
     }
 
@@ -419,7 +836,7 @@ impl Client {
         let bills = self.bill_store.get_bills().await?;
 
         for bill in bills {
-            self.subscribe_to_topic(bill.name).await?;
+            self.subscribe_to_bill_topic(&bill.name).await?;
         }
         Ok(())
     }
@@ -432,7 +849,7 @@ impl Client {
             let event = GossipsubEvent::new(GossipsubEventId::CommandGetChain, vec![0; 24]);
             let message = event.to_byte_array();
 
-            self.add_message_to_topic(message, bill.name).await?;
+            self.add_message_to_bill_topic(message, &bill.name).await?;
         }
         Ok(())
     }
@@ -441,17 +858,50 @@ impl Client {
     // Utility Functions for the DHT -------------------------------
     // -------------------------------------------------------------
 
-    /// Sends the given message to the given topic via the event loop
-    pub async fn add_message_to_topic(&mut self, msg: Vec<u8>, topic: String) -> Result<()> {
+    async fn add_message_to_topic(&mut self, msg: Vec<u8>, topic: String) -> Result<()> {
         self.send_message(msg, topic).await?;
         Ok(())
     }
 
-    /// Subscribe to the given topic via the event loop
-    pub async fn subscribe_to_topic(&mut self, topic: String) -> Result<()> {
+    /// Sends the given message to the given bill topic via the event loop
+    pub async fn add_message_to_bill_topic(&mut self, msg: Vec<u8>, topic: &str) -> Result<()> {
+        let key = self.bill_key(topic);
+        self.add_message_to_topic(msg, key).await?;
+        Ok(())
+    }
+
+    async fn subscribe_to_topic(&mut self, topic: String) -> Result<()> {
         self.sender
             .send(Command::SubscribeToTopic { topic })
             .await?;
+        Ok(())
+    }
+
+    async fn unsubscribe_from_topic(&mut self, topic: String) -> Result<()> {
+        self.sender
+            .send(Command::UnsubscribeFromTopic { topic })
+            .await?;
+        Ok(())
+    }
+
+    /// Subscribe to the given bill topic via the event loop
+    pub async fn subscribe_to_bill_topic(&mut self, topic: &str) -> Result<()> {
+        let key = self.bill_key(topic);
+        self.subscribe_to_topic(key).await?;
+        Ok(())
+    }
+
+    /// Subscribe to the given company topic via the event loop
+    pub async fn subscribe_to_company_topic(&mut self, topic: &str) -> Result<()> {
+        let key = self.company_key(topic);
+        self.subscribe_to_topic(key).await?;
+        Ok(())
+    }
+
+    /// Unsubscribe from the given company topic via the event loop
+    pub async fn unsubscribe_from_company_topic(&mut self, topic: &str) -> Result<()> {
+        let key = self.company_key(topic);
+        self.unsubscribe_from_topic(key).await?;
         Ok(())
     }
 
@@ -464,7 +914,7 @@ impl Client {
     }
 
     /// Puts the given value into the DHT at the given key via the event loop
-    pub async fn put_record(&mut self, key: String, value: String) -> Result<()> {
+    pub async fn put_record(&mut self, key: String, value: Vec<u8>) -> Result<()> {
         self.sender.send(Command::PutRecord { key, value }).await?;
         Ok(())
     }
@@ -477,8 +927,7 @@ impl Client {
         Ok(record)
     }
 
-    /// Adds the current node to the list of providers for the given entry via the event loop
-    pub async fn start_providing(&mut self, entry: String) -> Result<()> {
+    async fn start_providing(&mut self, entry: String) -> Result<()> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Command::StartProviding { entry, sender })
@@ -487,14 +936,54 @@ impl Client {
         Ok(())
     }
 
+    async fn stop_providing(&mut self, entry: String) -> Result<()> {
+        self.sender.send(Command::StopProviding { entry }).await?;
+        Ok(())
+    }
+
+    /// Adds the current node to the list of providers for the given bill via the event loop
+    pub async fn start_providing_bill(&mut self, bill_name: &str) -> Result<()> {
+        let key = self.bill_key(bill_name);
+        self.start_providing(key).await?;
+        Ok(())
+    }
+
+    /// Adds the current node to the list of providers for the given company via the event loop
+    pub async fn start_providing_company(&mut self, company_id: &str) -> Result<()> {
+        let key = self.company_key(company_id);
+        self.start_providing(key).await?;
+        Ok(())
+    }
+
+    /// Removes the current node from the list of providers for the given company via the event loop
+    pub async fn stop_providing_company(&mut self, company_id: &str) -> Result<()> {
+        let key = self.company_key(company_id);
+        self.stop_providing(key).await?;
+        Ok(())
+    }
+
     /// Gets the providers for the given file via the event loop
-    pub async fn get_providers(&mut self, entry: String) -> Result<HashSet<PeerId>> {
+    async fn get_providers(&mut self, entry: String) -> Result<HashSet<PeerId>> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(Command::GetProviders { entry, sender })
             .await
             .expect("Command receiver not to be dropped.");
         let providers = receiver.await?;
+        Ok(providers)
+    }
+
+    /// Gets the providers for the given bill via the event loop
+    pub async fn get_bill_providers(&mut self, bill_id: &str) -> Result<HashSet<PeerId>> {
+        let entry = self.bill_key(bill_id);
+        let providers = self.get_providers(entry).await?;
+        Ok(providers)
+    }
+
+    /// Gets the providers for the given company via the event loop
+    pub async fn get_company_providers(&mut self, company_id: &str) -> Result<HashSet<PeerId>> {
+        let entry = self.company_key(company_id);
+        let providers = self.get_providers(entry).await?;
         Ok(providers)
     }
 
@@ -524,10 +1013,121 @@ impl Client {
         Ok(())
     }
 
+    // -----------------------------------------------------
+    // Event Handling --------------------------------------
+    // -----------------------------------------------------
+
+    // We check if the node id is part of the signatories, and if so, send the
+    // company data
+    async fn handle_company_data_file_request(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+        channel: ResponseChannel<FileResponse>,
+    ) -> Result<()> {
+        let company = self.company_store.get(company_id).await?;
+        if company.signatories.iter().any(|v| v == node_id) {
+            let bytes = company_to_bytes(&company)?;
+            self.respond_file(bytes, channel).await?;
+        }
+        Ok(())
+    }
+
+    // We check if the node id is part of the signatories, and if so, send the
+    // company keys encrypted with the node's public key
+    async fn handle_company_keys_file_request(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+        channel: ResponseChannel<FileResponse>,
+    ) -> Result<()> {
+        let company = self.company_store.get(company_id).await?;
+        if company.signatories.iter().any(|v| v == node_id) {
+            let public_data = self
+                .get_identity_public_data_from_dht(node_id.to_owned())
+                .await?;
+            let public_key = public_data.rsa_public_key_pem;
+            let keys = self.company_store.get_key_pair(company_id).await?;
+            let bytes = company_keys_to_bytes(&keys)?;
+            let file_encrypted = encrypt_bytes_with_public_key(&bytes, &public_key);
+            self.respond_file(file_encrypted, channel).await?;
+        }
+        Ok(())
+    }
+
+    // We check if the node id is part of the signatories, and if so,
+    // open the logo file, if there is one, decrypt it and send the
+    // given file, encrypted with the node's public key
+    async fn handle_company_logo_file_request(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+        file_name: &str,
+        channel: ResponseChannel<FileResponse>,
+    ) -> Result<()> {
+        let company = self.company_store.get(company_id).await?;
+        if company.signatories.iter().any(|v| v == node_id) {
+            if let Some(logo) = company.logo_file {
+                if logo.name == *file_name {
+                    self.handle_company_file_request_for_file(
+                        company_id, node_id, file_name, channel,
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    // We check if the node id is part of the signatories, and if so,
+    // open the logo file, if there is one, decrypt it and send the
+    // given file, encrypted with the node's public key
+    async fn handle_company_proof_file_request(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+        file_name: &str,
+        channel: ResponseChannel<FileResponse>,
+    ) -> Result<()> {
+        let company = self.company_store.get(company_id).await?;
+        if company.signatories.iter().any(|v| v == node_id) {
+            if let Some(proof) = company.proof_of_registration_file {
+                if proof.name == *file_name {
+                    self.handle_company_file_request_for_file(
+                        company_id, node_id, file_name, channel,
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_company_file_request_for_file(
+        &mut self,
+        company_id: &str,
+        node_id: &str,
+        file_name: &str,
+        channel: ResponseChannel<FileResponse>,
+    ) -> Result<()> {
+        let public_data = self
+            .get_identity_public_data_from_dht(node_id.to_owned())
+            .await?;
+        let public_key = public_data.rsa_public_key_pem;
+        let bytes = self
+            .company_store
+            .open_attached_file(company_id, file_name)
+            .await?;
+        let identity_private_key = self.identity_store.get().await?.private_key_pem;
+        let decrypted_bytes = decrypt_bytes_with_private_key(&bytes, identity_private_key);
+        let file_encrypted = encrypt_bytes_with_public_key(&decrypted_bytes, &public_key);
+        self.respond_file(file_encrypted, channel).await?;
+        Ok(())
+    }
+
     // -------------------------------------------------------------
     // Request handling code ---------------------------------------
     // -------------------------------------------------------------
-
     /// Handles incoming requests
     async fn handle_event(&mut self, event: Event) {
         let Event::InboundRequest { request, channel } = event;
@@ -537,6 +1137,62 @@ impl Client {
             }
             Ok(parsed) => {
                 match parsed {
+                    ParsedInboundFileRequest::CompanyData(CompanyDataRequest {
+                        company_id,
+                        node_id,
+                    }) => {
+                        if let Err(e) = self
+                            .handle_company_data_file_request(&company_id, &node_id, channel)
+                            .await
+                        {
+                            error!("Could not handle inbound request {request}: {e}")
+                        }
+                    }
+                    ParsedInboundFileRequest::CompanyKeys(CompanyKeysRequest {
+                        node_id,
+                        company_id,
+                    }) => {
+                        if let Err(e) = self
+                            .handle_company_keys_file_request(&company_id, &node_id, channel)
+                            .await
+                        {
+                            error!("Could not handle inbound request {request}: {e}")
+                        }
+                    }
+                    ParsedInboundFileRequest::CompanyLogo(CompanyLogoRequest {
+                        node_id,
+                        company_id,
+                        file_name,
+                    }) => {
+                        if let Err(e) = self
+                            .handle_company_logo_file_request(
+                                &company_id,
+                                &node_id,
+                                &file_name,
+                                channel,
+                            )
+                            .await
+                        {
+                            error!("Could not handle inbound request {request}: {e}")
+                        }
+                    }
+                    ParsedInboundFileRequest::CompanyProof(CompanyProofRequest {
+                        node_id,
+                        company_id,
+                        file_name,
+                    }) => {
+                        if let Err(e) = self
+                            .handle_company_proof_file_request(
+                                &company_id,
+                                &node_id,
+                                &file_name,
+                                channel,
+                            )
+                            .await
+                        {
+                            error!("Could not handle inbound request {request}: {e}")
+                        }
+                    }
                     // We can send the bill to anyone requesting it, since the content is encrypted
                     // and is useless without the keys
                     ParsedInboundFileRequest::Bill(BillFileRequest { bill_name }) => {

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -338,13 +338,13 @@ impl EventLoop {
 
     async fn handle_command(&mut self, command: Command) {
         match command {
-            Command::StartProviding { file_name, sender } => {
-                info!("Start providing {file_name:?}");
+            Command::StartProviding { entry, sender } => {
+                info!("Start providing {entry:?}");
                 let query_id = self
                     .swarm
                     .behaviour_mut()
                     .kademlia
-                    .start_providing(file_name.into_bytes().into())
+                    .start_providing(entry.into_bytes().into())
                     .expect("Can not provide.");
                 self.pending_start_providing.insert(query_id, sender);
             }
@@ -399,13 +399,13 @@ impl EventLoop {
                 self.pending_get_records.insert(query_id, sender);
             }
 
-            Command::GetProviders { file_name, sender } => {
-                info!("Get providers {file_name:?}");
+            Command::GetProviders { entry, sender } => {
+                info!("Get providers {entry:?}");
                 let query_id = self
                     .swarm
                     .behaviour_mut()
                     .kademlia
-                    .get_providers(file_name.into_bytes().into());
+                    .get_providers(entry.into_bytes().into());
                 self.pending_get_providers.insert(query_id, sender);
             }
 

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -22,6 +22,7 @@ mod client;
 mod event_loop;
 
 use crate::persistence::bill::BillStoreApi;
+use crate::persistence::company::CompanyStoreApi;
 use crate::persistence::identity::IdentityStoreApi;
 use crate::{persistence, util};
 pub use client::Client;
@@ -109,10 +110,11 @@ pub struct Dht {
 pub async fn dht_main(
     conf: &Config,
     bill_store: Arc<dyn BillStoreApi>,
+    company_store: Arc<dyn CompanyStoreApi>,
     identity_store: Arc<dyn IdentityStoreApi>,
 ) -> Result<Dht> {
     let (network_client, network_events, network_event_loop) =
-        new(conf, bill_store, identity_store).await?;
+        new(conf, bill_store, company_store, identity_store).await?;
 
     let (shutdown_sender, shutdown_receiver) = broadcast::channel::<bool>(100);
 
@@ -139,6 +141,7 @@ pub async fn dht_main(
 async fn new(
     conf: &Config,
     bill_store: Arc<dyn BillStoreApi>,
+    company_store: Arc<dyn CompanyStoreApi>,
     identity_store: Arc<dyn IdentityStoreApi>,
 ) -> Result<(Client, Receiver<Event>, EventLoop)> {
     if !identity_store.exists().await {
@@ -285,7 +288,7 @@ async fn new(
     let event_loop = EventLoop::new(swarm, command_receiver, event_sender);
 
     Ok((
-        Client::new(command_sender, bill_store, identity_store),
+        Client::new(command_sender, bill_store, company_store, identity_store),
         event_receiver,
         event_loop,
     ))

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     env_logger::init();
 
     // You can now use USERNETWORK globally
-    println!("Chosen Network: {:?}", *USERNETWORK);
+    info!("Chosen Network: {:?}", *USERNETWORK);
 
     // Parse command line arguments and env vars with clap
     let conf = Config::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
 
     dht_client.put_identity_public_data_in_dht().await?;
 
-    dht_client.check_new_companies().await?;
+    dht_client.check_companies().await?;
     dht_client.put_companies_for_signatories().await?;
     dht_client.put_companies_public_data_in_dht().await?;
     dht_client.start_providing_companies().await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,14 @@ async fn main() -> Result<()> {
     dht_client.put_bills_for_parties().await?;
     dht_client.start_providing_bills().await?;
     dht_client.receive_updates_for_all_bills_topics().await?;
+
     dht_client.put_identity_public_data_in_dht().await?;
+
+    dht_client.check_new_companies().await?;
+    dht_client.put_companies_for_signatories().await?;
     dht_client.put_companies_public_data_in_dht().await?;
+    dht_client.start_providing_companies().await?;
+    dht_client.subscribe_to_all_companies_topics().await?;
 
     let web_server_error_shutdown_sender = dht.shutdown_sender.clone();
     let service_context =

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -56,6 +56,26 @@ pub trait CompanyStoreApi: Send + Sync {
     async fn open_attached_file(&self, id: &str, file_name: &str) -> Result<Vec<u8>>;
 }
 
+pub fn company_from_bytes(bytes: &[u8]) -> Result<Company> {
+    let company: Company = serde_json::from_slice(bytes)?;
+    Ok(company)
+}
+
+pub fn company_to_bytes(company: &Company) -> Result<Vec<u8>> {
+    let bytes = serde_json::to_vec(&company)?;
+    Ok(bytes)
+}
+
+pub fn company_keys_from_bytes(bytes: &[u8]) -> Result<CompanyKeys> {
+    let company_keys: CompanyKeys = serde_json::from_slice(bytes)?;
+    Ok(company_keys)
+}
+
+pub fn company_keys_to_bytes(company_keys: &CompanyKeys) -> Result<Vec<u8>> {
+    let bytes = serde_json::to_vec(&company_keys)?;
+    Ok(bytes)
+}
+
 #[derive(Clone)]
 pub struct FileBasedCompanyStore {
     folder: String,
@@ -107,7 +127,7 @@ impl CompanyStoreApi for FileBasedCompanyStore {
     async fn get(&self, id: &str) -> Result<Company> {
         let path = self.get_path_for_company_data(id);
         let bytes = read(path).await?;
-        let company: Company = serde_json::from_slice(&bytes)?;
+        let company = company_from_bytes(&bytes)?;
         Ok(company)
     }
 

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -711,8 +711,7 @@ impl BillServiceApi for BillService {
         }
 
         client.subscribe_to_topic(bill_name.to_owned()).await?;
-
-        client.put(bill_name).await?;
+        client.start_providing(bill_name.to_owned()).await?;
         Ok(())
     }
 
@@ -1055,7 +1054,8 @@ mod test {
     use libp2p::{identity::Keypair, PeerId};
     use mockall::predicate::{always, eq};
     use persistence::{
-        bill::MockBillStoreApi, file_upload::MockFileUploadStoreApi, identity::MockIdentityStoreApi,
+        bill::MockBillStoreApi, company::MockCompanyStoreApi, file_upload::MockFileUploadStoreApi,
+        identity::MockIdentityStoreApi,
     };
     use std::sync::Arc;
 
@@ -1113,6 +1113,7 @@ mod test {
             Client::new(
                 sender,
                 Arc::new(MockBillStoreApi::new()),
+                Arc::new(MockCompanyStoreApi::new()),
                 Arc::new(MockIdentityStoreApi::new()),
             ),
             Arc::new(mock_storage),
@@ -1130,6 +1131,7 @@ mod test {
             Client::new(
                 sender,
                 Arc::new(MockBillStoreApi::new()),
+                Arc::new(MockCompanyStoreApi::new()),
                 Arc::new(MockIdentityStoreApi::new()),
             ),
             Arc::new(mock_storage),
@@ -1147,6 +1149,7 @@ mod test {
             Client::new(
                 sender,
                 Arc::new(MockBillStoreApi::new()),
+                Arc::new(MockCompanyStoreApi::new()),
                 Arc::new(MockIdentityStoreApi::new()),
             ),
             Arc::new(mock_storage),

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -519,10 +519,7 @@ impl BillServiceApi for BillService {
     }
 
     async fn find_bill_in_dht(&self, bill_name: &str) -> Result<()> {
-        let bill_bytes = self.client.clone().get_bill(bill_name).await?;
-        self.store
-            .write_bill_to_file(bill_name, &bill_bytes)
-            .await?;
+        self.client.clone().get_bill(bill_name).await?;
         Ok(())
     }
 
@@ -681,7 +678,7 @@ impl BillServiceApi for BillService {
 
         self.client
             .clone()
-            .add_message_to_topic(message, bill_name.to_owned())
+            .add_message_to_bill_topic(message, bill_name)
             .await?;
         Ok(())
     }
@@ -710,8 +707,8 @@ impl BillServiceApi for BillService {
             }
         }
 
-        client.subscribe_to_topic(bill_name.to_owned()).await?;
-        client.start_providing(bill_name.to_owned()).await?;
+        client.subscribe_to_bill_topic(bill_name).await?;
+        client.start_providing_bill(bill_name).await?;
         Ok(())
     }
 

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -402,6 +402,27 @@ pub struct Company {
     pub signatories: Vec<String>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct CompanyPublicData {
+    pub id: String,
+    pub legal_name: String,
+    pub postal_address: String,
+    pub legal_email: String,
+    pub public_key: String,
+}
+
+impl CompanyPublicData {
+    pub fn from(id: String, company: Company, company_keys: CompanyKeys) -> CompanyPublicData {
+        CompanyPublicData {
+            id,
+            legal_name: company.legal_name,
+            postal_address: company.postal_address,
+            legal_email: company.legal_email,
+            public_key: company_keys.public_key,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CompanyKeys {
     pub private_key: String,

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -412,13 +412,25 @@ pub struct CompanyPublicData {
 }
 
 impl CompanyPublicData {
-    pub fn from(id: String, company: Company, company_keys: CompanyKeys) -> CompanyPublicData {
+    pub fn from_all(id: String, company: Company, company_keys: CompanyKeys) -> CompanyPublicData {
         CompanyPublicData {
             id,
             legal_name: company.legal_name,
             postal_address: company.postal_address,
             legal_email: company.legal_email,
             public_key: company_keys.public_key,
+        }
+    }
+}
+
+impl From<CompanyToReturn> for CompanyPublicData {
+    fn from(company: CompanyToReturn) -> Self {
+        Self {
+            id: company.id,
+            legal_name: company.legal_name,
+            postal_address: company.postal_address,
+            legal_email: company.legal_email,
+            public_key: company.public_key,
         }
     }
 }

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -217,7 +217,9 @@ impl Identity {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::persistence::{self, bill::MockBillStoreApi, identity::MockIdentityStoreApi};
+    use crate::persistence::{
+        self, bill::MockBillStoreApi, company::MockCompanyStoreApi, identity::MockIdentityStoreApi,
+    };
     use futures::channel::mpsc;
 
     fn get_service(mock_storage: MockIdentityStoreApi) -> IdentityService {
@@ -228,6 +230,7 @@ mod test {
             Client::new(
                 sender,
                 Arc::new(MockBillStoreApi::new()),
+                Arc::new(MockCompanyStoreApi::new()),
                 Arc::new(client_storage),
             ),
             Arc::new(mock_storage),

--- a/src/util/terminal.rs
+++ b/src/util/terminal.rs
@@ -1,5 +1,6 @@
 use crate::dht::Client;
 use anyhow::Result;
+use borsh::to_vec;
 use log::{error, info};
 use std::io::BufRead;
 use tokio::sync::broadcast;
@@ -49,7 +50,7 @@ pub async fn run_terminal_client(
 async fn handle_input_line(dht_client: &mut Client, line: String) {
     let mut args = line.split(' ');
     match args.next() {
-        Some("START_PROVIDING") => {
+        Some("START_PROVIDING_COMPANY") => {
             let name: String = {
                 match args.next() {
                     Some(name) => String::from(name),
@@ -59,8 +60,23 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
                     }
                 }
             };
-            if let Err(e) = dht_client.start_providing(name.clone()).await {
-                error!("Could not start providing {name}: {e}");
+            if let Err(e) = dht_client.start_providing_company(&name).await {
+                error!("Could not start providing company {name}: {e}");
+            };
+        }
+
+        Some("START_PROVIDING_BILL") => {
+            let name: String = {
+                match args.next() {
+                    Some(name) => String::from(name),
+                    None => {
+                        error!("Expected name.");
+                        return;
+                    }
+                }
+            };
+            if let Err(e) = dht_client.start_providing_bill(&name).await {
+                error!("Could not start providing bill {name}: {e}");
             };
         }
 
@@ -128,19 +144,26 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
                     }
                 }
             };
-            let value = {
-                match args.next() {
-                    Some(value) => String::from(value),
-                    None => {
-                        error!("Expected value");
-                        return;
+            let mut values = vec![];
+            for value in args.by_ref() {
+                values.push(value.to_owned());
+            }
+
+            if values.is_empty() {
+                error!("Expected value");
+                return;
+            }
+
+            match to_vec(&values) {
+                Ok(v) => {
+                    if let Err(e) = dht_client.put_record(key.clone(), v).await {
+                        error!("Could not put record {values:?} to {key}: {e}");
                     }
                 }
+                Err(e) => {
+                    error!("Could not serialize value {values:?} to bytes: {e}");
+                }
             };
-
-            if let Err(e) = dht_client.put_record(key.clone(), value.clone()).await {
-                error!("Could not put record {value} to {key}: {e}");
-            }
         }
 
         Some("SEND_MESSAGE") => {
@@ -171,7 +194,7 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
             }
         }
 
-        Some("SUBSCRIBE") => {
+        Some("SUBSCRIBE_TO_COMPANY") => {
             let topic = {
                 match args.next() {
                     Some(key) => String::from(key),
@@ -182,7 +205,23 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
                 }
             };
 
-            if let Err(e) = dht_client.subscribe_to_topic(topic.clone()).await {
+            if let Err(e) = dht_client.subscribe_to_company_topic(&topic).await {
+                error!("Could not subscribe to topic {topic}: {e}");
+            }
+        }
+
+        Some("SUBSCRIBE_TO_BILL") => {
+            let topic = {
+                match args.next() {
+                    Some(key) => String::from(key),
+                    None => {
+                        error!("Expected topic");
+                        return;
+                    }
+                }
+            };
+
+            if let Err(e) = dht_client.subscribe_to_bill_topic(&topic).await {
                 error!("Could not subscribe to topic {topic}: {e}");
             }
         }
@@ -202,7 +241,7 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
             }
         }
 
-        Some("GET_PROVIDERS") => {
+        Some("GET_BILL_PROVIDERS") => {
             let key = {
                 match args.next() {
                     Some(key) => String::from(key),
@@ -212,14 +251,14 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
                     }
                 }
             };
-            if let Err(e) = dht_client.get_providers(key.clone()).await {
-                error!("Could not get providers for {key}: {e}");
+            if let Err(e) = dht_client.get_bill_providers(&key).await {
+                error!("Could not get bill providers for {key}: {e}");
             }
         }
 
         _ => {
             error!(
-                "expected GET_BILL, GET_KEY, GET_BILL_ATTACHMENT, PUT, SEND_MESSAGE, SUBSCRIBE, GET_RECORD, PUT_RECORD or GET_PROVIDERS."
+                "expected GET_BILL, GET_KEY, GET_BILL_ATTACHMENT, PUT, SEND_MESSAGE, SUBSCRIBE_TO_BILL, SUBSCRIBE_TO_COMPANY, GET_RECORD, PUT_RECORD, START_PROVIDING_BILL, START_PROVIDING_COMPANY or GET_PROVIDERS."
             );
         }
     }

--- a/src/util/terminal.rs
+++ b/src/util/terminal.rs
@@ -49,7 +49,7 @@ pub async fn run_terminal_client(
 async fn handle_input_line(dht_client: &mut Client, line: String) {
     let mut args = line.split(' ');
     match args.next() {
-        Some("PUT") => {
+        Some("START_PROVIDING") => {
             let name: String = {
                 match args.next() {
                     Some(name) => String::from(name),
@@ -59,8 +59,8 @@ async fn handle_input_line(dht_client: &mut Client, line: String) {
                     }
                 }
             };
-            if let Err(e) = dht_client.put(&name).await {
-                error!("Could not put {name}: {e}");
+            if let Err(e) = dht_client.start_providing(name.clone()).await {
+                error!("Could not start providing {name}: {e}");
             };
         }
 

--- a/src/web/handlers/company/mod.rs
+++ b/src/web/handlers/company/mod.rs
@@ -9,9 +9,25 @@ use crate::{
     web::data::{UploadFileForm, UploadFilesResponse},
 };
 use data::{AddSignatoryPayload, CreateCompanyPayload, EditCompanyPayload, RemoveSignatoryPayload};
-use rocket::{form::Form, get, http::ContentType, post, put, serde::json::Json, State};
+use rocket::{
+    form::Form,
+    get,
+    http::{ContentType, Status},
+    post, put,
+    serde::json::Json,
+    State,
+};
 
 pub mod data;
+
+#[get("/check_dht")]
+pub async fn check_companies_in_dht(state: &State<ServiceContext>) -> Result<Status> {
+    if !state.identity_service.identity_exists().await {
+        return Err(service::Error::PreconditionFailed);
+    }
+    state.dht_client().check_companies().await?;
+    Ok(Status::Ok)
+}
 
 #[get("/list")]
 pub async fn list(state: &State<ServiceContext>) -> Result<Json<Vec<CompanyToReturn>>> {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -51,6 +51,7 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
         .mount(
             "/company",
             routes![
+                handlers::company::check_companies_in_dht,
                 handlers::company::list,
                 handlers::company::detail,
                 handlers::company::get_file,


### PR DESCRIPTION
This implements the DHT interaction logic when it comes to companies and fixes #139. This is a pre-identity/company blockchain implementation, so it just implements the basics to share company data between signatories, without checking if the data on the DHT is consistent.

In the course of this implementation, I also documented the DHT logic and refactored/fixed it up a bit. Especially, I added coherent prefixes to all of the data on the DHT, so we don't run into conflicts there.

It re-uses the file-sharing implementation for bills and is structured similar to bills, but implements parallelization and cleaner interfaces. Most of the logic, we'll be needing in one way or another even after moving parts to Nostr.

The DHT interactions implemented here:

* On creating a company
  * Publish the public data of the company to the DHT
  * Subscribe to messages on the company topic
  * Start providing the company on the network
  * Add the company id to my list of companies on the DHT
* On editing a company
  * Publish the new public data to the DHT
* On adding a signatory
  * Add the company to the signatory's list of companies on the DHT
  * Sends a message to the topic to add a signatory
* On removing a signatory
  * Remove the company from the signatory's list of companies on the DHT
  * If it's myself, stop providing and subscribing as well
  * Sends a message to the topic to remove the signatory
* On startup
  * Check for new companies I'm a part of - if there are, get all the data locally from a 
provider
  * If I'm locally part of a company the network tells me I'm not a part of, delete the company
  * Put my local company data as public data on the DHT
  * Update all signatories for all companies on the DHT (to keep the network state up2date)
  * Start providing all my companies
  * Subscribe to all my companies