### PR TITLE
Migrate critical code paths to use Rust Result error handling

### DIFF
--- a/src/bill/mod.rs
+++ b/src/bill/mod.rs
@@ -19,12 +19,13 @@ pub fn get_path_for_bill_keys(key_name: &str) -> PathBuf {
     path
 }
 
-pub fn bill_from_byte_array(bill: &[u8]) -> BitcreditBill {
-    BitcreditBill::try_from_slice(bill).unwrap()
+pub fn bill_from_byte_array(bill: &[u8]) -> Result<BitcreditBill, borsh::maybestd::io::Error> {
+    BitcreditBill::try_from_slice(bill)
 }
 
-pub fn read_keys_from_bill_file(bill_name: &str) -> BillKeys {
+pub fn read_keys_from_bill_file(bill_name: &str) -> Result<BillKeys, std::io::Error> {
     let input_path = get_path_for_bill_keys(bill_name);
-    let blockchain_from_file = fs::read(input_path.clone()).expect("file not found");
-    serde_json::from_slice(blockchain_from_file.as_slice()).unwrap()
+    let blockchain_from_file = fs::read(input_path)?;
+    let bill_keys: BillKeys = serde_json::from_slice(blockchain_from_file.as_slice())?;
+    Ok(bill_keys)
 }

--- a/src/bill/quotes.rs
+++ b/src/bill/quotes.rs
@@ -5,77 +5,79 @@ use moksha_core::primitives::CheckBitcreditQuoteResponse;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::io::Error;
 
-pub fn read_quotes_map() -> HashMap<String, BitcreditEbillQuote> {
+pub fn read_quotes_map() -> Result<HashMap<String, BitcreditEbillQuote>, Error> {
     if !Path::new(QUOTE_MAP_FILE_PATH).exists() {
-        create_quotes_map();
+        create_quotes_map()?;
     }
-    let data: Vec<u8> = fs::read(QUOTE_MAP_FILE_PATH).expect("Unable to read quotes.");
-    let quotes: HashMap<String, BitcreditEbillQuote> = HashMap::try_from_slice(&data).unwrap();
-    quotes
+    let data: Vec<u8> = fs::read(QUOTE_MAP_FILE_PATH)?;
+    let quotes: HashMap<String, BitcreditEbillQuote> = HashMap::try_from_slice(&data)?;
+    Ok(quotes)
 }
 
-pub fn create_quotes_map() {
+pub fn create_quotes_map() -> Result<(), Error> {
     let quotes: HashMap<String, BitcreditEbillQuote> = HashMap::new();
-    write_quotes_map(quotes);
+    write_quotes_map(quotes)
 }
 
-pub fn write_quotes_map(map: HashMap<String, BitcreditEbillQuote>) {
-    let quotes_byte = to_vec(&map).unwrap();
-    fs::write(QUOTE_MAP_FILE_PATH, quotes_byte).expect("Unable to write quote in file.");
+pub fn write_quotes_map(map: HashMap<String, BitcreditEbillQuote>) -> Result<(), Error> {
+    let quotes_byte = to_vec(&map)?;
+    fs::write(QUOTE_MAP_FILE_PATH, quotes_byte)?;
+    Ok(())
 }
 
-pub fn add_in_quotes_map(quote: BitcreditEbillQuote) {
+pub fn add_in_quotes_map(quote: BitcreditEbillQuote) -> Result<(), Error> {
     if !Path::new(QUOTE_MAP_FILE_PATH).exists() {
-        create_quotes_map();
+        create_quotes_map()?;
     }
 
-    let mut quotes: HashMap<String, BitcreditEbillQuote> = read_quotes_map();
+    let mut quotes: HashMap<String, BitcreditEbillQuote> = read_quotes_map()?;
 
     quotes.insert(quote.bill_id.clone(), quote);
-    write_quotes_map(quotes);
+    write_quotes_map(quotes)
 }
 
-pub fn get_quote_from_map(bill_id: &String) -> BitcreditEbillQuote {
-    let quotes = read_quotes_map();
+pub fn get_quote_from_map(bill_id: &String) -> Result<BitcreditEbillQuote, Error> {
+    let quotes = read_quotes_map()?;
     if quotes.contains_key(bill_id) {
         let data = quotes.get(bill_id).unwrap().clone();
-        data
+        Ok(data)
     } else {
-        BitcreditEbillQuote::new_empty()
+        Ok(BitcreditEbillQuote::new_empty())
     }
 }
 
 pub fn add_bitcredit_quote_and_amount_in_quotes_map(
     response: CheckBitcreditQuoteResponse,
     bill_id: String,
-) {
+) -> Result<(), Error> {
     if !Path::new(QUOTE_MAP_FILE_PATH).exists() {
-        create_quotes_map();
+        create_quotes_map()?;
     }
 
-    let mut quotes: HashMap<String, BitcreditEbillQuote> = read_quotes_map();
-    let mut quote = get_quote_from_map(&bill_id);
+    let mut quotes: HashMap<String, BitcreditEbillQuote> = read_quotes_map()?;
+    let mut quote = get_quote_from_map(&bill_id)?;
 
     quote.amount = response.amount;
     quote.quote_id = response.quote.clone();
 
     quotes.remove(&bill_id);
     quotes.insert(bill_id.clone(), quote);
-    write_quotes_map(quotes);
+    write_quotes_map(quotes)
 }
 
-pub fn add_bitcredit_token_in_quotes_map(token: String, bill_id: String) {
+pub fn add_bitcredit_token_in_quotes_map(token: String, bill_id: String) -> Result<(), Error> {
     if !Path::new(QUOTE_MAP_FILE_PATH).exists() {
-        create_quotes_map();
+        create_quotes_map()?;
     }
 
-    let mut quotes: HashMap<String, BitcreditEbillQuote> = read_quotes_map();
-    let mut quote = get_quote_from_map(&bill_id);
+    let mut quotes: HashMap<String, BitcreditEbillQuote> = read_quotes_map()?;
+    let mut quote = get_quote_from_map(&bill_id)?;
 
     quote.token = token.clone();
 
     quotes.remove(&bill_id);
     quotes.insert(bill_id.clone(), quote);
-    write_quotes_map(quotes);
+    write_quotes_map(quotes)
 }

--- a/src/blockchain/block.rs
+++ b/src/blockchain/block.rs
@@ -18,6 +18,7 @@ use openssl::rsa::Rsa;
 use openssl::sign::Signer;
 use openssl::sign::Verifier;
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Block {
@@ -101,7 +102,7 @@ impl Block {
     /// A `Vec<String>` containing the unique peer IDs involved in the block. Peer IDs are included
     /// only if they are non-empty and not already part of the list.
     ///
-    pub fn get_nodes_from_block(&self, bill: BitcreditBill) -> Vec<String> {
+    pub fn get_nodes_from_block(&self, bill: BitcreditBill) -> Result<Vec<String>, Box<dyn Error>> {
         let mut nodes = Vec::new();
         match self.operation_code {
             Issue => {
@@ -121,18 +122,18 @@ impl Block {
                 }
             }
             Endorse => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let mut part_with_endorsee = block_data_decrypted
                     .split("Endorsed to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse endorsee part")?
                     .to_string();
 
                 let part_with_endorsed_by = part_with_endorsee
@@ -140,45 +141,45 @@ impl Block {
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse endorsed by part")?
                     .to_string();
 
                 part_with_endorsee = part_with_endorsee
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse endorsee part")?
                     .to_string();
 
-                let endorsee_bill_u8 = hex::decode(part_with_endorsee).unwrap();
+                let endorsee_bill_u8 = hex::decode(part_with_endorsee)?;
                 let endorsee_bill: IdentityPublicData =
-                    serde_json::from_slice(&endorsee_bill_u8).unwrap();
+                    serde_json::from_slice(&endorsee_bill_u8)?;
                 let endorsee_bill_name = endorsee_bill.peer_id.clone();
                 if !endorsee_bill_name.is_empty() && !nodes.contains(&endorsee_bill_name) {
                     nodes.push(endorsee_bill_name);
                 }
 
-                let endorser_bill_u8 = hex::decode(part_with_endorsed_by).unwrap();
+                let endorser_bill_u8 = hex::decode(part_with_endorsed_by)?;
                 let endorser_bill: IdentityPublicData =
-                    serde_json::from_slice(&endorser_bill_u8).unwrap();
+                    serde_json::from_slice(&endorser_bill_u8)?;
                 let endorser_bill_name = endorser_bill.peer_id.clone();
                 if !endorser_bill_name.is_empty() && !nodes.contains(&endorser_bill_name) {
                     nodes.push(endorser_bill_name);
                 }
             }
             Mint => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let mut part_with_mint = block_data_decrypted
                     .split("Endorsed to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse mint part")?
                     .to_string();
 
                 let part_with_minter = part_with_mint
@@ -186,48 +187,48 @@ impl Block {
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse minter part")?
                     .to_string();
 
                 part_with_mint = part_with_mint
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse mint part")?
                     .to_string();
 
-                let mint_bill_u8 = hex::decode(part_with_mint).unwrap();
-                let mint_bill: IdentityPublicData = serde_json::from_slice(&mint_bill_u8).unwrap();
+                let mint_bill_u8 = hex::decode(part_with_mint)?;
+                let mint_bill: IdentityPublicData = serde_json::from_slice(&mint_bill_u8)?;
                 let mint_bill_name = mint_bill.peer_id.clone();
                 if !mint_bill_name.is_empty() && !nodes.contains(&mint_bill_name) {
                     nodes.push(mint_bill_name);
                 }
 
-                let minter_bill_u8 = hex::decode(part_with_minter).unwrap();
+                let minter_bill_u8 = hex::decode(part_with_minter)?;
                 let minter_bill: IdentityPublicData =
-                    serde_json::from_slice(&minter_bill_u8).unwrap();
+                    serde_json::from_slice(&minter_bill_u8)?;
                 let minter_bill_name = minter_bill.peer_id.clone();
                 if !minter_bill_name.is_empty() && !nodes.contains(&minter_bill_name) {
                     nodes.push(minter_bill_name);
                 }
             }
             RequestToAccept => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_identity = block_data_decrypted
                     .split("Requested to accept by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse identity part")?
                     .to_string();
-                let requester_to_accept_bill_u8 = hex::decode(part_with_identity).unwrap();
+                let requester_to_accept_bill_u8 = hex::decode(part_with_identity)?;
                 let requester_to_accept_bill: IdentityPublicData =
-                    serde_json::from_slice(&requester_to_accept_bill_u8).unwrap();
+                    serde_json::from_slice(&requester_to_accept_bill_u8)?;
                 let requester_to_accept_bill_name = requester_to_accept_bill.peer_id.clone();
                 if !requester_to_accept_bill_name.is_empty()
                     && !nodes.contains(&requester_to_accept_bill_name)
@@ -236,44 +237,44 @@ impl Block {
                 }
             }
             Accept => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_identity = block_data_decrypted
                     .split("Accepted by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse identity part")?
                     .to_string();
-                let accepter_bill_u8 = hex::decode(part_with_identity).unwrap();
+                let accepter_bill_u8 = hex::decode(part_with_identity)?;
                 let accepter_bill: IdentityPublicData =
-                    serde_json::from_slice(&accepter_bill_u8).unwrap();
+                    serde_json::from_slice(&accepter_bill_u8)?;
                 let accepter_bill_name = accepter_bill.peer_id.clone();
                 if !accepter_bill_name.is_empty() && !nodes.contains(&accepter_bill_name) {
                     nodes.push(accepter_bill_name);
                 }
             }
             RequestToPay => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_identity = block_data_decrypted
                     .split("Requested to pay by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse identity part")?
                     .to_string();
-                let requester_to_pay_bill_u8 = hex::decode(part_with_identity).unwrap();
+                let requester_to_pay_bill_u8 = hex::decode(part_with_identity)?;
                 let requester_to_pay_bill: IdentityPublicData =
-                    serde_json::from_slice(&requester_to_pay_bill_u8).unwrap();
+                    serde_json::from_slice(&requester_to_pay_bill_u8)?;
                 let requester_to_pay_bill_name = requester_to_pay_bill.peer_id.clone();
                 if !requester_to_pay_bill_name.is_empty()
                     && !nodes.contains(&requester_to_pay_bill_name)
@@ -282,25 +283,25 @@ impl Block {
                 }
             }
             Sell => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_without_sold_to = block_data_decrypted
                     .split("Sold to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse sold to part")?
                     .to_string();
 
                 let part_with_buyer = part_without_sold_to
                     .split(" sold by ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse buyer part")?
                     .to_string();
 
                 let part_with_seller_and_amount = part_without_sold_to
@@ -308,7 +309,7 @@ impl Block {
                     .split(" sold by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse seller and amount part")?
                     .to_string();
 
                 let part_with_seller = part_with_seller_and_amount
@@ -316,27 +317,27 @@ impl Block {
                     .split(" amount: ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse seller part")?
                     .to_string();
 
-                let buyer_bill_u8 = hex::decode(part_with_buyer).unwrap();
+                let buyer_bill_u8 = hex::decode(part_with_buyer)?;
                 let buyer_bill: IdentityPublicData =
-                    serde_json::from_slice(&buyer_bill_u8).unwrap();
+                    serde_json::from_slice(&buyer_bill_u8)?;
                 let buyer_peer_id = buyer_bill.peer_id.clone();
                 if !buyer_peer_id.is_empty() && !nodes.contains(&buyer_peer_id) {
                     nodes.push(buyer_peer_id);
                 }
 
-                let seller_bill_u8 = hex::decode(part_with_seller).unwrap();
+                let seller_bill_u8 = hex::decode(part_with_seller)?;
                 let seller_bill: IdentityPublicData =
-                    serde_json::from_slice(&seller_bill_u8).unwrap();
+                    serde_json::from_slice(&seller_bill_u8)?;
                 let seller_bill_peer_id = seller_bill.peer_id.clone();
                 if !seller_bill_peer_id.is_empty() && !nodes.contains(&seller_bill_peer_id) {
                     nodes.push(seller_bill_peer_id);
                 }
             }
         }
-        nodes
+        Ok(nodes)
     }
 
     /// Generates a human-readable history label for a `BitcreditBill` based on the operation code.
@@ -348,40 +349,40 @@ impl Block {
     /// # Returns
     /// A `String` representing the history label for the given bill.
     ///
-    pub fn get_history_label(&self, bill: BitcreditBill) -> String {
+    pub fn get_history_label(&self, bill: BitcreditBill) -> Result<String, Box<dyn Error>> {
         match self.operation_code {
             Issue => {
                 let time_of_issue = Utc.timestamp_opt(self.timestamp, 0).unwrap();
                 if !bill.drawer.name.is_empty() {
-                    format!(
+                    Ok(format!(
                         "Bill issued by {} at {} in {}",
                         bill.drawer.name, time_of_issue, bill.place_of_drawing
-                    )
+                    ))
                 } else if bill.to_payee {
-                    format!(
+                    Ok(format!(
                         "Bill issued by {} at {} in {}",
                         bill.payee.name, time_of_issue, bill.place_of_drawing
-                    )
+                    ))
                 } else {
-                    format!(
+                    Ok(format!(
                         "Bill issued by {} at {} in {}",
                         bill.drawee.name, time_of_issue, bill.place_of_drawing
-                    )
+                    ))
                 }
             }
             Endorse => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_endorsee = block_data_decrypted
                     .split("Endorsed to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse endorsee part")?
                     .to_string();
 
                 let part_with_endorsed_by = part_with_endorsee
@@ -389,28 +390,28 @@ impl Block {
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse endorsed by part")?
                     .to_string();
 
-                let endorser_bill_u8 = hex::decode(part_with_endorsed_by).unwrap();
+                let endorser_bill_u8 = hex::decode(part_with_endorsed_by)?;
                 let endorser_bill: IdentityPublicData =
-                    serde_json::from_slice(&endorser_bill_u8).unwrap();
+                    serde_json::from_slice(&endorser_bill_u8)?;
 
-                endorser_bill.name + ", " + &endorser_bill.postal_address
+                Ok(endorser_bill.name + ", " + &endorser_bill.postal_address)
             }
             Mint => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_mint = block_data_decrypted
                     .split("Endorsed to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse mint part")?
                     .to_string();
 
                 let part_with_minter = part_with_mint
@@ -418,106 +419,106 @@ impl Block {
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse minter part")?
                     .to_string();
 
-                let minter_bill_u8 = hex::decode(part_with_minter).unwrap();
+                let minter_bill_u8 = hex::decode(part_with_minter)?;
                 let minter_bill: IdentityPublicData =
-                    serde_json::from_slice(&minter_bill_u8).unwrap();
+                    serde_json::from_slice(&minter_bill_u8)?;
 
-                minter_bill.name + ", " + &minter_bill.postal_address
+                Ok(minter_bill.name + ", " + &minter_bill.postal_address)
             }
             RequestToAccept => {
                 let time_of_request_to_accept = Utc.timestamp_opt(self.timestamp, 0).unwrap();
 
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_identity = block_data_decrypted
                     .split("Requested to accept by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse identity part")?
                     .to_string();
-                let requester_to_accept_bill_u8 = hex::decode(part_with_identity).unwrap();
+                let requester_to_accept_bill_u8 = hex::decode(part_with_identity)?;
                 let requester_to_accept_bill: IdentityPublicData =
-                    serde_json::from_slice(&requester_to_accept_bill_u8).unwrap();
+                    serde_json::from_slice(&requester_to_accept_bill_u8)?;
 
-                format!(
+                Ok(format!(
                     "Bill requested to accept by {} at {} in {}",
                     requester_to_accept_bill.name,
                     time_of_request_to_accept,
                     requester_to_accept_bill.postal_address
-                )
+                ))
             }
             Accept => {
                 let time_of_accept = Utc.timestamp_opt(self.timestamp, 0).unwrap();
 
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_identity = block_data_decrypted
                     .split("Accepted by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse identity part")?
                     .to_string();
-                let accepter_bill_u8 = hex::decode(part_with_identity).unwrap();
+                let accepter_bill_u8 = hex::decode(part_with_identity)?;
                 let accepter_bill: IdentityPublicData =
-                    serde_json::from_slice(&accepter_bill_u8).unwrap();
+                    serde_json::from_slice(&accepter_bill_u8)?;
 
-                format!(
+                Ok(format!(
                     "Bill accepted by {} at {} in {}",
                     accepter_bill.name, time_of_accept, accepter_bill.postal_address
-                )
+                ))
             }
             RequestToPay => {
                 let time_of_request_to_pay = Utc.timestamp_opt(self.timestamp, 0).unwrap();
 
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_with_identity = block_data_decrypted
                     .split("Requested to pay by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse identity part")?
                     .to_string();
-                let requester_to_pay_bill_u8 = hex::decode(part_with_identity).unwrap();
+                let requester_to_pay_bill_u8 = hex::decode(part_with_identity)?;
                 let requester_to_pay_bill: IdentityPublicData =
-                    serde_json::from_slice(&requester_to_pay_bill_u8).unwrap();
-                format!(
+                    serde_json::from_slice(&requester_to_pay_bill_u8)?;
+                Ok(format!(
                     "Bill requested to pay by {} at {} in {}",
                     requester_to_pay_bill.name,
                     time_of_request_to_pay,
                     requester_to_pay_bill.postal_address
-                )
+                ))
             }
             Sell => {
-                let bill_keys = read_keys_from_bill_file(&self.bill_name);
+                let bill_keys = read_keys_from_bill_file(&self.bill_name)?;
                 let key: Rsa<Private> =
-                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-                let bytes = hex::decode(self.data.clone()).unwrap();
+                    Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+                let bytes = hex::decode(self.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_without_sold_to = block_data_decrypted
                     .split("Sold to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse sold to part")?
                     .to_string();
 
                 let part_with_seller_and_amount = part_without_sold_to
@@ -525,7 +526,7 @@ impl Block {
                     .split(" sold by ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse seller and amount part")?
                     .to_string();
 
                 let part_with_seller = part_with_seller_and_amount
@@ -533,14 +534,14 @@ impl Block {
                     .split(" amount: ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse seller part")?
                     .to_string();
 
-                let seller_bill_u8 = hex::decode(part_with_seller).unwrap();
+                let seller_bill_u8 = hex::decode(part_with_seller)?;
                 let seller_bill: IdentityPublicData =
-                    serde_json::from_slice(&seller_bill_u8).unwrap();
+                    serde_json::from_slice(&seller_bill_u8)?;
 
-                seller_bill.name + ", " + &seller_bill.postal_address
+                Ok(seller_bill.name + ", " + &seller_bill.postal_address)
             }
         }
     }
@@ -555,18 +556,18 @@ impl Block {
     /// - `true` if the signature is valid.
     /// - `false` if the signature is invalid.
     ///
-    pub fn verifier(&self) -> bool {
+    pub fn verifier(&self) -> Result<bool, Box<dyn Error>> {
         let public_key_bytes = self.public_key.as_bytes();
-        let public_key_rsa = public_key_from_pem_u8(public_key_bytes);
-        let verifier_key = PKey::from_rsa(public_key_rsa).unwrap();
+        let public_key_rsa = public_key_from_pem_u8(public_key_bytes)?;
+        let verifier_key = PKey::from_rsa(public_key_rsa)?;
 
-        let mut verifier = Verifier::new(MessageDigest::sha256(), verifier_key.as_ref()).unwrap();
+        let mut verifier = Verifier::new(MessageDigest::sha256(), verifier_key.as_ref())?;
 
         let data_to_check = self.hash.as_bytes();
-        verifier.update(data_to_check).unwrap();
+        verifier.update(data_to_check)?;
 
-        let signature_bytes = hex::decode(&self.signature).unwrap();
-        verifier.verify(signature_bytes.as_slice()).unwrap()
+        let signature_bytes = hex::decode(&self.signature)?;
+        Ok(verifier.verify(signature_bytes.as_slice())?)
     }
 }
 

--- a/src/blockchain/chain.rs
+++ b/src/blockchain/chain.rs
@@ -194,14 +194,14 @@ impl Chain {
     /// A `BitcreditBill` object containing the most recent version of the bill, including the payee, endorsee,
     /// and other associated information.
     ///
-    pub async fn get_last_version_bill(&self, bill_keys: &BillKeys) -> BitcreditBill {
+    pub async fn get_last_version_bill(&self, bill_keys: &BillKeys) -> Result<BitcreditBill> {
         let first_block = self.get_first_block();
 
         let key: Rsa<Private> =
-            Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-        let bytes = hex::decode(first_block.data.clone()).unwrap();
+            Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+        let bytes = hex::decode(first_block.data.clone())?;
         let decrypted_bytes = decrypt_bytes(&bytes, &key);
-        let bill_first_version: BitcreditBill = bill_from_byte_array(&decrypted_bytes);
+        let bill_first_version: BitcreditBill = bill_from_byte_array(&decrypted_bytes)?;
 
         let mut last_endorsee = IdentityPublicData {
             peer_id: "".to_string(),
@@ -226,81 +226,81 @@ impl Chain {
             let last_version_block_sell = self.get_last_version_block_with_operation_code(Sell);
             let last_block = self.get_latest_block();
 
-            let paid = Self::check_if_last_sell_block_is_paid(self).await;
+            let paid = Self::check_if_last_sell_block_is_paid(self).await?;
 
             if (last_version_block_endorse.id < last_version_block_sell.id)
                 && (last_version_block_mint.id < last_version_block_sell.id)
                 && ((last_block.id > last_version_block_sell.id) || paid)
             {
-                let bytes = hex::decode(last_version_block_sell.data.clone()).unwrap();
+                let bytes = hex::decode(last_version_block_sell.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let part_without_sold_to = block_data_decrypted
                     .split("Sold to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse sold to part")?
                     .to_string();
 
                 let part_with_buyer = part_without_sold_to
                     .split(" sold by ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse buyer part")?
                     .to_string();
 
-                let buyer_bill_u8 = hex::decode(part_with_buyer).unwrap();
+                let buyer_bill_u8 = hex::decode(part_with_buyer)?;
                 let buyer_bill: IdentityPublicData =
-                    serde_json::from_slice(&buyer_bill_u8).unwrap();
+                    serde_json::from_slice(&buyer_bill_u8)?;
 
                 last_endorsee = buyer_bill.clone();
             } else if self.exist_block_with_operation_code(Endorse.clone())
                 && (last_version_block_endorse.id > last_version_block_mint.id)
             {
-                let bytes = hex::decode(last_version_block_endorse.data.clone()).unwrap();
+                let bytes = hex::decode(last_version_block_endorse.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let mut part_with_endorsee = block_data_decrypted
                     .split("Endorsed to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse endorsee part")?
                     .to_string();
 
                 part_with_endorsee = part_with_endorsee
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse endorsee part")?
                     .to_string();
 
-                let endorsee = hex::decode(part_with_endorsee).unwrap();
-                last_endorsee = serde_json::from_slice(&endorsee).unwrap();
+                let endorsee = hex::decode(part_with_endorsee)?;
+                last_endorsee = serde_json::from_slice(&endorsee)?;
             } else if self.exist_block_with_operation_code(Mint.clone())
                 && (last_version_block_mint.id > last_version_block_endorse.id)
             {
-                let bytes = hex::decode(last_version_block_mint.data.clone()).unwrap();
+                let bytes = hex::decode(last_version_block_mint.data.clone())?;
                 let decrypted_bytes = decrypt_bytes(&bytes, &key);
-                let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+                let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
                 let mut part_with_mint = block_data_decrypted
                     .split("Endorsed to ")
                     .collect::<Vec<&str>>()
                     .get(1)
-                    .unwrap()
+                    .ok_or("Failed to parse mint part")?
                     .to_string();
 
                 part_with_mint = part_with_mint
                     .split(" endorsed by ")
                     .collect::<Vec<&str>>()
                     .first()
-                    .unwrap()
+                    .ok_or("Failed to parse mint part")?
                     .to_string();
 
-                let mint = hex::decode(part_with_mint).unwrap();
-                last_endorsee = serde_json::from_slice(&mint).unwrap();
+                let mint = hex::decode(part_with_mint)?;
+                last_endorsee = serde_json::from_slice(&mint)?;
             }
         }
 
@@ -310,7 +310,7 @@ impl Chain {
             payee = last_endorsee.clone();
         }
 
-        BitcreditBill {
+        Ok(BitcreditBill {
             name: bill_first_version.name,
             to_payee: bill_first_version.to_payee,
             bill_jurisdiction: bill_first_version.bill_jurisdiction,
@@ -332,7 +332,7 @@ impl Chain {
             private_key: bill_first_version.private_key,
             language: bill_first_version.language,
             files: bill_first_version.files,
-        }
+        })
     }
 
     /// Checks if the payment for the latest sell block has been made, and returns relevant information about the buyer, seller, and the payment status.
@@ -347,7 +347,7 @@ impl Chain {
     ///
     pub async fn waiting_for_payment(
         &self,
-    ) -> (bool, IdentityPublicData, IdentityPublicData, String, u64) {
+    ) -> Result<(bool, IdentityPublicData, IdentityPublicData, String, u64)> {
         let last_block = self.get_latest_block();
         let last_version_block_sell = self.get_last_version_block_with_operation_code(Sell);
         let identity_buyer = IdentityPublicData::new_empty();
@@ -356,25 +356,25 @@ impl Chain {
         if self.exist_block_with_operation_code(Sell.clone())
             && last_block.id == last_version_block_sell.id
         {
-            let bill_keys = read_keys_from_bill_file(&last_version_block_sell.bill_name);
+            let bill_keys = read_keys_from_bill_file(&last_version_block_sell.bill_name)?;
             let key: Rsa<Private> =
-                Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-            let bytes = hex::decode(last_version_block_sell.data.clone()).unwrap();
+                Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+            let bytes = hex::decode(last_version_block_sell.data.clone())?;
             let decrypted_bytes = decrypt_bytes(&bytes, &key);
-            let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+            let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
             let part_without_sold_to = block_data_decrypted
                 .split("Sold to ")
                 .collect::<Vec<&str>>()
                 .get(1)
-                .unwrap()
+                .ok_or("Failed to parse sold to part")?
                 .to_string();
 
             let part_with_buyer = part_without_sold_to
                 .split(" sold by ")
                 .collect::<Vec<&str>>()
                 .first()
-                .unwrap()
+                .ok_or("Failed to parse buyer part")?
                 .to_string();
 
             let part_with_seller_and_amount = part_without_sold_to
@@ -382,7 +382,7 @@ impl Chain {
                 .split(" sold by ")
                 .collect::<Vec<&str>>()
                 .get(1)
-                .unwrap()
+                .ok_or("Failed to parse seller and amount part")?
                 .to_string();
 
             let amount: u64 = part_with_seller_and_amount
@@ -390,28 +390,27 @@ impl Chain {
                 .split(" amount: ")
                 .collect::<Vec<&str>>()
                 .get(1)
-                .unwrap()
+                .ok_or("Failed to parse amount part")?
                 .to_string()
-                .parse()
-                .unwrap();
+                .parse()?;
 
             let part_with_seller = part_with_seller_and_amount
                 .clone()
                 .split(" amount: ")
                 .collect::<Vec<&str>>()
                 .first()
-                .unwrap()
+                .ok_or("Failed to parse seller part")?
                 .to_string();
 
-            let buyer_bill_u8 = hex::decode(part_with_buyer).unwrap();
-            let buyer_bill: IdentityPublicData = serde_json::from_slice(&buyer_bill_u8).unwrap();
+            let buyer_bill_u8 = hex::decode(part_with_buyer)?;
+            let buyer_bill: IdentityPublicData = serde_json::from_slice(&buyer_bill_u8)?;
             let identity_buyer = buyer_bill;
 
-            let seller_bill_u8 = hex::decode(part_with_seller).unwrap();
-            let seller_bill: IdentityPublicData = serde_json::from_slice(&seller_bill_u8).unwrap();
+            let seller_bill_u8 = hex::decode(part_with_seller)?;
+            let seller_bill: IdentityPublicData = serde_json::from_slice(&seller_bill_u8)?;
             let identity_seller = seller_bill;
 
-            let bill = self.get_first_version_bill();
+            let bill = self.get_first_version_bill()?;
 
             let address_to_pay =
                 Self::get_address_to_pay_for_block_sell(last_version_block_sell.clone(), bill);
@@ -421,34 +420,34 @@ impl Chain {
             let (paid, _amount) =
                 external::bitcoin::check_if_paid(address_to_pay_for_async, amount).await;
 
-            (
+            Ok((
                 !paid,
                 identity_buyer,
                 identity_seller,
                 address_to_pay,
                 amount,
-            )
+            ))
         } else {
-            (false, identity_buyer, identity_seller, String::new(), 0)
+            Ok((false, identity_buyer, identity_seller, String::new(), 0))
         }
     }
 
     /// This asynchronous function checks if the payment deadline associated with the most recent sell block
     /// has passed.
-    /// # Returns
+    # Returns
     ///
     /// - `true` if the payment deadline for the last sell block has passed.
     /// - `false` if no sell block exists or the deadline has not passed.
     ///
-    pub async fn check_if_payment_deadline_has_passed(&self) -> bool {
+    pub async fn check_if_payment_deadline_has_passed(&self) -> Result<bool> {
         if self.exist_block_with_operation_code(Sell) {
             let last_version_block_sell = self.get_last_version_block_with_operation_code(Sell);
 
             let timestamp = last_version_block_sell.timestamp;
 
-            Self::payment_deadline_has_passed(timestamp, 2).await
+            Ok(Self::payment_deadline_has_passed(timestamp, 2).await?)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -464,14 +463,13 @@ impl Chain {
     ///
     /// `true` if the payment deadline has passed, otherwise `false`.
     ///
-    async fn payment_deadline_has_passed(timestamp: i64, day: i32) -> bool {
+    async fn payment_deadline_has_passed(timestamp: i64, day: i32) -> Result<bool> {
         let period: i64 = (86400 * day) as i64;
         let current_timestamp = external::time::TimeApi::get_atomic_time()
-            .await
-            .unwrap()
+            .await?
             .timestamp;
         let diference = current_timestamp - timestamp;
-        diference > period
+        Ok(diference > period)
     }
 
     /// This asynchronous function verifies whether the last block that involves a "Sell" operation
@@ -482,22 +480,22 @@ impl Chain {
     ///
     /// `true` if the payment has been made, otherwise `false`. If no "Sell" block exists, it returns `false`.
     ///
-    async fn check_if_last_sell_block_is_paid(&self) -> bool {
+    async fn check_if_last_sell_block_is_paid(&self) -> Result<bool> {
         if self.exist_block_with_operation_code(Sell) {
             let last_version_block_sell = self.get_last_version_block_with_operation_code(Sell);
 
-            let bill_keys = read_keys_from_bill_file(&last_version_block_sell.bill_name);
+            let bill_keys = read_keys_from_bill_file(&last_version_block_sell.bill_name)?;
             let key: Rsa<Private> =
-                Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-            let bytes = hex::decode(last_version_block_sell.data.clone()).unwrap();
+                Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+            let bytes = hex::decode(last_version_block_sell.data.clone())?;
             let decrypted_bytes = decrypt_bytes(&bytes, &key);
-            let block_data_decrypted = String::from_utf8(decrypted_bytes).unwrap();
+            let block_data_decrypted = String::from_utf8(decrypted_bytes)?;
 
             let part_without_sold_to = block_data_decrypted
                 .split("Sold to ")
                 .collect::<Vec<&str>>()
                 .get(1)
-                .unwrap()
+                .ok_or("Failed to parse sold to part")?
                 .to_string();
 
             let part_with_seller_and_amount = part_without_sold_to
@@ -505,7 +503,7 @@ impl Chain {
                 .split(" sold by ")
                 .collect::<Vec<&str>>()
                 .get(1)
-                .unwrap()
+                .ok_or("Failed to parse seller and amount part")?
                 .to_string();
 
             let amount: u64 = part_with_seller_and_amount
@@ -513,21 +511,20 @@ impl Chain {
                 .split(" amount: ")
                 .collect::<Vec<&str>>()
                 .get(1)
-                .unwrap()
+                .ok_or("Failed to parse amount part")?
                 .to_string()
-                .parse()
-                .unwrap();
+                .parse()?;
 
-            let bill = self.get_first_version_bill();
+            let bill = self.get_first_version_bill()?;
 
             let address_to_pay =
                 Self::get_address_to_pay_for_block_sell(last_version_block_sell.clone(), bill);
 
-            external::bitcoin::check_if_paid(address_to_pay, amount)
+            Ok(external::bitcoin::check_if_paid(address_to_pay, amount)
                 .await
-                .0
+                .0)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -552,7 +549,7 @@ impl Chain {
     ) -> String {
         let public_key_bill = bitcoin::PublicKey::from_str(&bill.public_key).unwrap();
 
-        let bill_keys = read_keys_from_bill_file(&last_version_block_sell.bill_name);
+        let bill_keys = read_keys_from_bill_file(&last_version_block_sell.bill_name).unwrap();
         let key: Rsa<Private> =
             Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
         let bytes = hex::decode(last_version_block_sell.data.clone()).unwrap();
@@ -608,19 +605,19 @@ impl Chain {
     ///
     /// * `BitcreditBill` - The first version of the bill, decrypted and deserialized from
     ///   the data in the first block.
-    pub fn get_first_version_bill_with_keys(&self, bill_keys: &BillKeys) -> BitcreditBill {
+    pub fn get_first_version_bill_with_keys(&self, bill_keys: &BillKeys) -> Result<BitcreditBill> {
         let first_block_data = &self.get_first_block();
         let key: Rsa<Private> =
-            Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
-        let bytes = hex::decode(first_block_data.data.clone()).unwrap();
+            Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes())?;
+        let bytes = hex::decode(first_block_data.data.clone())?;
         let decrypted_bytes = decrypt_bytes(&bytes, &key);
-        let bill_first_version: BitcreditBill = bill_from_byte_array(&decrypted_bytes);
-        bill_first_version
+        let bill_first_version: BitcreditBill = bill_from_byte_array(&decrypted_bytes)?;
+        Ok(bill_first_version)
     }
 
-    pub fn get_first_version_bill(&self) -> BitcreditBill {
+    pub fn get_first_version_bill(&self) -> Result<BitcreditBill> {
         let first_block_data = &self.get_first_block();
-        let bill_keys = read_keys_from_bill_file(&first_block_data.bill_name);
+        let bill_keys = read_keys_from_bill_file(&first_block_data.bill_name)?;
         self.get_first_version_bill_with_keys(&bill_keys)
     }
 
@@ -688,8 +685,8 @@ impl Chain {
         let mut nodes: Vec<String> = Vec::new();
 
         for block in &self.blocks {
-            let bill = self.get_first_version_bill();
-            let nodes_in_block = block.get_nodes_from_block(bill);
+            let bill = self.get_first_version_bill().unwrap();
+            let nodes_in_block = block.get_nodes_from_block(bill).unwrap();
             for node in nodes_in_block {
                 if !node.is_empty() && !nodes.contains(&node) {
                     nodes.push(node);
@@ -708,9 +705,9 @@ impl Chain {
     /// `IdentityPublicData`:  
     /// - The identity data of the drawer, payee, or drawee depending on the evaluated conditions.
     ///
-    pub fn get_drawer(&self, bill_keys: &BillKeys) -> IdentityPublicData {
+    pub fn get_drawer(&self, bill_keys: &BillKeys) -> Result<IdentityPublicData> {
         let drawer: IdentityPublicData;
-        let bill = self.get_first_version_bill_with_keys(bill_keys);
+        let bill = self.get_first_version_bill_with_keys(bill_keys)?;
         if !bill.drawer.name.is_empty() {
             drawer = bill.drawer.clone();
         } else if bill.to_payee {
@@ -718,7 +715,7 @@ impl Chain {
         } else {
             drawer = bill.drawee.clone();
         }
-        drawer
+        Ok(drawer)
     }
 
     /// This function iterates through all blocks in a bill's blockchain and verifies
@@ -739,7 +736,7 @@ impl Chain {
         for block in &self.blocks {
             match block.operation_code {
                 Issue => {
-                    let bill = self.get_first_version_bill();
+                    let bill = self.get_first_version_bill().unwrap();
                     if bill.drawer.peer_id.eq(request_node_id)
                         || bill.drawee.peer_id.eq(request_node_id)
                         || bill.payee.peer_id.eq(request_node_id)
@@ -750,7 +747,7 @@ impl Chain {
                 Endorse => {
                     let block = self.get_block_by_id(block.id);
 
-                    let bill_keys = read_keys_from_bill_file(&block.bill_name);
+                    let bill_keys = read_keys_from_bill_file(&block.bill_name).unwrap();
                     let key: Rsa<Private> =
                         Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
                     let bytes = hex::decode(block.data.clone()).unwrap();
@@ -796,7 +793,7 @@ impl Chain {
                 Mint => {
                     let block = self.get_block_by_id(block.id);
 
-                    let bill_keys = read_keys_from_bill_file(&block.bill_name);
+                    let bill_keys = read_keys_from_bill_file(&block.bill_name).unwrap();
                     let key: Rsa<Private> =
                         Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
                     let bytes = hex::decode(block.data.clone()).unwrap();
@@ -842,7 +839,7 @@ impl Chain {
                 RequestToAccept => {
                     let block = self.get_block_by_id(block.id);
 
-                    let bill_keys = read_keys_from_bill_file(&block.bill_name);
+                    let bill_keys = read_keys_from_bill_file(&block.bill_name).unwrap();
                     let key: Rsa<Private> =
                         Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
                     let bytes = hex::decode(block.data.clone()).unwrap();
@@ -866,7 +863,7 @@ impl Chain {
                 Accept => {
                     let block = self.get_block_by_id(block.id);
 
-                    let bill_keys = read_keys_from_bill_file(&block.bill_name);
+                    let bill_keys = read_keys_from_bill_file(&block.bill_name).unwrap();
                     let key: Rsa<Private> =
                         Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
                     let bytes = hex::decode(block.data.clone()).unwrap();
@@ -890,7 +887,7 @@ impl Chain {
                 RequestToPay => {
                     let block = self.get_block_by_id(block.id);
 
-                    let bill_keys = read_keys_from_bill_file(&block.bill_name);
+                    let bill_keys = read_keys_from_bill_file(&block.bill_name).unwrap();
                     let key: Rsa<Private> =
                         Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
                     let bytes = hex::decode(block.data.clone()).unwrap();
@@ -914,7 +911,7 @@ impl Chain {
                 Sell => {
                     let block = self.get_block_by_id(block.id);
 
-                    let bill_keys = read_keys_from_bill_file(&block.bill_name);
+                    let bill_keys = read_keys_from_bill_file(&block.bill_name).unwrap();
                     let key: Rsa<Private> =
                         Rsa::private_key_from_pem(bill_keys.private_key_pem.as_bytes()).unwrap();
                     let bytes = hex::decode(block.data.clone()).unwrap();
@@ -1007,7 +1004,7 @@ fn is_block_valid(block: &Block, previous_block: &Block) -> bool {
     {
         warn!("block with id: {} has invalid hash", block.id);
         return false;
-    } else if !block.verifier() {
+    } else if !block.verifier().unwrap() {
         warn!("block with id: {} has invalid signature", block.id);
         return false;
     }

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -154,7 +154,8 @@ pub fn start_blockchain_for_new_bill(
     _private_key: String,
     _private_key_pem: String,
     _timestamp: i64,
-) {
+) -> Result<()> {
+    Ok(())
 }
 #[cfg(not(test))]
 pub fn start_blockchain_for_new_bill(
@@ -165,15 +166,15 @@ pub fn start_blockchain_for_new_bill(
     private_key: String,
     private_key_pem: String,
     timestamp: i64,
-) {
+) -> Result<()> {
     use crate::bill::get_path_for_bill;
 
-    let data_for_new_block_in_bytes = serde_json::to_vec(&drawer).unwrap();
+    let data_for_new_block_in_bytes = serde_json::to_vec(&drawer)?;
     let data_for_new_block = "Signed by ".to_string() + &hex::encode(data_for_new_block_in_bytes);
 
     let genesis_hash: String = hex::encode(data_for_new_block.as_bytes());
 
-    let bill_data: String = encrypted_hash_data_from_bill(bill, private_key_pem);
+    let bill_data: String = encrypted_hash_data_from_bill(bill, private_key_pem)?;
 
     let first_block = Block::new(
         1,
@@ -188,7 +189,8 @@ pub fn start_blockchain_for_new_bill(
 
     let chain = Chain::new(first_block);
     let output_path = get_path_for_bill(&bill.name);
-    std::fs::write(output_path, serde_json::to_string_pretty(&chain).unwrap()).unwrap();
+    std::fs::write(output_path, serde_json::to_string_pretty(&chain)?)?;
+    Ok(())
 }
 
 fn calculate_hash(
@@ -215,10 +217,10 @@ fn calculate_hash(
 }
 
 #[cfg_attr(test, allow(dead_code))]
-fn encrypted_hash_data_from_bill(bill: &BitcreditBill, private_key_pem: String) -> String {
-    let bytes = to_vec(bill).unwrap();
-    let key: Rsa<Private> = Rsa::private_key_from_pem(private_key_pem.as_bytes()).unwrap();
+fn encrypted_hash_data_from_bill(bill: &BitcreditBill, private_key_pem: String) -> Result<String> {
+    let bytes = to_vec(bill)?;
+    let key: Rsa<Private> = Rsa::private_key_from_pem(private_key_pem.as_bytes())?;
     let encrypted_bytes = encrypt_bytes(&bytes, &key);
 
-    hex::encode(encrypted_bytes)
+    Ok(hex::encode(encrypted_bytes))
 }

--- a/src/external/mint.rs
+++ b/src/external/mint.rs
@@ -27,84 +27,77 @@ pub async fn accept_mint_bitcredit(
     amount: u64,
     bill_id: String,
     node_id: String,
-) -> PostMintQuoteBitcreditResponse {
+) -> Result<PostMintQuoteBitcreditResponse, Box<dyn std::error::Error>> {
     let dir = PathBuf::from("./data/wallet".to_string());
-    let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
+    let db_path = dir.join("wallet.db").to_str().ok_or("Invalid path")?.to_string();
     let localstore = SqliteLocalStore::with_path(db_path.clone())
-        .await
-        .expect("Cannot parse local store");
+        .await?;
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse("http://127.0.0.1:3338")?;
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
         .build()
-        .await
-        .expect("Could not create wallet");
+        .await?;
 
     let req = wallet.create_quote_bitcredit(&mint_url, bill_id, node_id, amount);
 
-    req.await.unwrap()
+    Ok(req.await?)
 }
 
 // Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
 // this logic will be replaced soon
 #[tokio::main]
-pub async fn check_bitcredit_quote(bill_id: &str, node_id: &str) {
+pub async fn check_bitcredit_quote(bill_id: &str, node_id: &str) -> Result<(), Box<dyn std::error::Error>> {
     let dir = PathBuf::from("./data/wallet".to_string());
-    let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
+    let db_path = dir.join("wallet.db").to_str().ok_or("Invalid path")?.to_string();
     let localstore = SqliteLocalStore::with_path(db_path.clone())
-        .await
-        .expect("Cannot parse local store");
+        .await?;
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse("http://127.0.0.1:3338")?;
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
         .build()
-        .await
-        .expect("Could not create wallet");
+        .await?;
 
     let result = wallet
         .check_bitcredit_quote(&mint_url, bill_id.to_owned(), node_id.to_owned())
-        .await;
+        .await?;
 
-    let quote = result.unwrap();
+    let quote = result;
 
     if !quote.quote.is_empty() {
-        add_bitcredit_quote_and_amount_in_quotes_map(quote.clone(), bill_id.to_owned());
+        add_bitcredit_quote_and_amount_in_quotes_map(quote.clone(), bill_id.to_owned())?;
     }
 
-    // quote
+    Ok(())
 }
 
 // Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
 // this logic will be replaced soon
 #[tokio::main]
-pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
+pub async fn client_accept_bitcredit_quote(bill_id: &String) -> Result<String, Box<dyn std::error::Error>> {
     let dir = PathBuf::from("./data/wallet".to_string());
-    let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
+    let db_path = dir.join("wallet.db").to_str().ok_or("Invalid path")?.to_string();
 
     let localstore = SqliteLocalStore::with_path(db_path.clone())
-        .await
-        .expect("Cannot parse local store");
+        .await?;
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse("http://127.0.0.1:3338")?;
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
         .build()
-        .await
-        .expect("Could not create wallet");
+        .await?;
 
     let clone_bill_id = bill_id.clone();
     let wallet_keysets = wallet
         .add_mint_keysets_by_id(&mint_url, "cr-sat".to_string(), clone_bill_id)
-        .await
-        .unwrap();
-    let wallet_keyset = wallet_keysets.first().unwrap();
+        .await?;
+    let wallet_keyset = wallet_keysets.first().ok_or("No keysets found")?;
 
-    let quote = get_quote_from_map(bill_id);
+    let quote = get_quote_from_map(bill_id)?;
     let quote_id = quote.quote_id.clone();
     let amount = quote.amount;
 
@@ -119,17 +112,15 @@ pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
                 quote_id,
                 CurrencyUnit::CrSat,
             )
-            .await;
+            .await?;
 
         token = result
-            .unwrap()
-            .serialize(Option::from(CurrencyUnit::CrSat))
-            .unwrap();
+            .serialize(Option::from(CurrencyUnit::CrSat))?;
 
-        add_bitcredit_token_in_quotes_map(token.clone(), bill_id.clone());
+        add_bitcredit_token_in_quotes_map(token.clone(), bill_id.clone())?;
     }
 
-    token
+    Ok(token)
 }
 
 // Usage of tokio::main to spawn a new runtime is necessary here, because Wallet is'nt Send - but
@@ -137,22 +128,20 @@ pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
 #[tokio::main]
 pub async fn request_to_mint_bitcredit(
     payload: RequestToMintBitcreditBillPayload,
-) -> PostRequestToMintBitcreditResponse {
+) -> Result<PostRequestToMintBitcreditResponse, Box<dyn std::error::Error>> {
     let dir = PathBuf::from("./data/wallet".to_string());
-    let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
+    let db_path = dir.join("wallet.db").to_str().ok_or("Invalid path")?.to_string();
     let localstore = SqliteLocalStore::with_path(db_path.clone())
-        .await
-        .expect("Cannot parse local store");
+        .await?;
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse("http://127.0.0.1:3338")?;
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
         .build()
-        .await
-        .expect("Could not create wallet");
+        .await?;
 
-    let bill_keys = read_keys_from_bill_file(&payload.bill_name.clone());
+    let bill_keys = read_keys_from_bill_file(&payload.bill_name.clone())?;
     let keys: BillKeys = BillKeys {
         private_key_pem: bill_keys.private_key_pem,
         public_key_pem: bill_keys.public_key_pem,
@@ -169,38 +158,28 @@ pub async fn request_to_mint_bitcredit(
         accepted: false,
         token: "".to_string(),
     };
-    safe_ebill_quote_locally(quote);
+    safe_ebill_quote_locally(quote)?;
 
-    req.await.unwrap()
+    Ok(req.await?)
 }
 
-pub fn safe_ebill_quote_locally(quote: BitcreditEbillQuote) {
-    let map = read_quotes_map();
+pub fn safe_ebill_quote_locally(quote: BitcreditEbillQuote) -> Result<(), Box<dyn std::error::Error>> {
+    let map = read_quotes_map()?;
     if !map.contains_key(&quote.bill_id) {
-        add_in_quotes_map(quote);
+        add_in_quotes_map(quote)?;
     }
+    Ok(())
 }
 
-pub async fn init_wallet() {
+pub async fn init_wallet() -> Result<(), Box<dyn std::error::Error>> {
     let dir = PathBuf::from("./data/wallet".to_string());
     if !dir.exists() {
-        fs::create_dir_all(dir.clone()).unwrap();
+        fs::create_dir_all(dir.clone())?;
     }
-    let db_path = dir.join("wallet.db").to_str().unwrap().to_string();
+    let db_path = dir.join("wallet.db").to_str().ok_or("Invalid path")?.to_string();
 
     let _localstore = SqliteLocalStore::with_path(db_path.clone())
-        .await
-        .expect("Cannot parse local store");
+        .await?;
 
-    // //TODO: take from params
-    // let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
-    //
-    // let identity: Identity = read_identity_from_file();
-    // let bitcoin_key = identity.bitcoin_public_key.clone();
-    //
-    // let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
-    //     .with_localstore(localstore)
-    //     .build()
-    //     .await
-    //     .expect("Could not create wallet");
+    Ok(())
 }


### PR DESCRIPTION
Fixes #138

Migrate critical code paths to use Rust `Result` error handling instead of `.unwrap()` or `.expect()`.

* **src/bill/mod.rs**
  - Replace `.unwrap()` with `Result` error handling in `bill_from_byte_array` and `read_keys_from_bill_file`.

* **src/bill/quotes.rs**
  - Replace `.unwrap()` with `Result` error handling in `read_quotes_map`, `write_quotes_map`, `get_quote_from_map`, and `add_bitcredit_token_in_quotes_map`.

* **src/blockchain/block.rs**
  - Replace `.unwrap()` with `Result` error handling in multiple functions, including `get_nodes_from_block`, `get_history_label`, and `verifier`.

* **src/blockchain/chain.rs**
  - Replace `.unwrap()` with `Result` error handling in `get_latest_bill`, `waiting_for_payment`, `check_if_payment_deadline_has_passed` and `check_if_last_sell_block_is_paid`.

* **src/blockchain/mod.rs**
  - Replace `.unwrap()` with `Result` error handling in `start_blockchain_for_new_bill` and `encrypted_hash_data_from_bill`.

* **src/external/bitcoin.rs**
  - Replace `.unwrap()` with `Result` error handling in `get_address_to_pay`.

* **src/external/mint.rs**
  - Replace `.unwrap()` with `Result` error handling in `accept_mint_bitcredit`, `check_bitcredit_quote`, `client_accept_bitcredit_quote` and `request_to_mint_bitcredit`.