### PR TITLE
140 secp signing and identity chain persistence

### DIFF
--- a/src/blockchain/bill/chain.rs
+++ b/src/blockchain/bill/chain.rs
@@ -13,7 +13,7 @@ use crate::constants::{AMOUNT, SIGNED_BY};
 use crate::service::bill_service::BillKeys;
 use crate::service::bill_service::BitcreditBill;
 use crate::service::contact_service::IdentityPublicData;
-use crate::util::rsa;
+use crate::util::{rsa, BcrKeys};
 use borsh::{from_slice, to_vec};
 use serde::{Deserialize, Serialize};
 
@@ -41,8 +41,7 @@ impl BillBlockchain {
         bill: &BitcreditBill,
         operation_code: BillOpCode,
         drawer: IdentityPublicData,
-        drawer_public_key: String,
-        drawer_private_key: String,
+        drawer_key_pair: BcrKeys,
         bill_public_key_pem: String,
         timestamp: i64,
     ) -> Result<Self> {
@@ -60,9 +59,8 @@ impl BillBlockchain {
             1,
             genesis_hash,
             encrypted_and_hashed_bill_data,
-            drawer_public_key,
             operation_code,
-            drawer_private_key,
+            drawer_key_pair,
             timestamp,
         )?;
 
@@ -341,7 +339,7 @@ mod test {
     use super::*;
     use crate::{
         blockchain::bill::test::get_baseline_identity,
-        tests::test::{get_bill_keys, TEST_PRIVATE_KEY, TEST_PUB_KEY},
+        tests::test::{get_bill_keys, TEST_PUB_KEY},
         util::rsa,
     };
     use libp2p::PeerId;
@@ -364,9 +362,8 @@ mod test {
             2,
             prevhash,
             hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
-            TEST_PUB_KEY.to_owned(),
             BillOpCode::Sell,
-            TEST_PRIVATE_KEY.to_owned(),
+            BcrKeys::new(),
             1731593928,
         )
         .unwrap()
@@ -381,8 +378,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -400,8 +396,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -422,8 +417,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -452,8 +446,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -480,8 +473,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -515,8 +507,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -543,8 +534,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -570,8 +560,7 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )

--- a/src/blockchain/bill/chain.rs
+++ b/src/blockchain/bill/chain.rs
@@ -39,7 +39,6 @@ impl BillBlockchain {
     /// key
     pub fn new(
         bill: &BitcreditBill,
-        operation_code: BillOpCode,
         drawer: IdentityPublicData,
         drawer_key_pair: BcrKeys,
         bill_public_key_pem: String,
@@ -59,7 +58,7 @@ impl BillBlockchain {
             1,
             genesis_hash,
             encrypted_and_hashed_bill_data,
-            operation_code,
+            BillOpCode::Issue,
             drawer_key_pair,
             timestamp,
         )?;
@@ -376,7 +375,6 @@ mod test {
 
         let chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -394,7 +392,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -415,7 +412,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -444,7 +440,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -471,7 +466,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -505,7 +499,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -532,7 +525,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),
@@ -558,7 +550,6 @@ mod test {
 
         let mut chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),

--- a/src/blockchain/bill/mod.rs
+++ b/src/blockchain/bill/mod.rs
@@ -136,7 +136,6 @@ mod test {
 
         let result = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
             identity.key_pair,
             TEST_PUB_KEY.to_owned(),

--- a/src/blockchain/bill/mod.rs
+++ b/src/blockchain/bill/mod.rs
@@ -67,7 +67,6 @@ pub struct BillBlockToReturn {
     pub data: String,
     pub previous_hash: String,
     pub signature: String,
-    pub public_key: String,
     pub operation_code: BillOpCode,
     pub label: String,
 }
@@ -85,7 +84,6 @@ impl BillBlockToReturn {
             data: block.data,
             previous_hash: block.previous_hash,
             signature: block.signature,
-            public_key: block.public_key,
             operation_code: block.operation_code,
             label,
         })
@@ -140,32 +138,13 @@ mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.public_key_pem,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         );
 
         assert!(result.is_ok());
         assert_eq!(result.as_ref().unwrap().blocks().len(), 1);
-    }
-
-    #[test]
-    fn start_blockchain_for_new_bill_baseline_fails_with_invalid_keys() {
-        let bill = BitcreditBill::new_empty();
-        let identity = get_baseline_identity();
-
-        let result = BillBlockchain::new(
-            &bill,
-            BillOpCode::Issue,
-            IdentityPublicData::new(identity.identity.clone(), identity.peer_id.to_string()),
-            identity.identity.private_key_pem, // swapped private and public
-            identity.identity.public_key_pem,
-            TEST_PUB_KEY.to_owned(),
-            1731593928,
-        );
-
-        assert!(result.is_err());
     }
 
     #[test]

--- a/src/blockchain/identity/mod.rs
+++ b/src/blockchain/identity/mod.rs
@@ -157,3 +157,20 @@ impl IdentityBlockchain {
         Ok(created)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tests::test::TEST_PUB_KEY;
+
+    #[test]
+    fn create_and_check_validity() {
+        let mut identity = Identity::new_empty();
+        identity.public_key_pem = TEST_PUB_KEY.to_string();
+
+        let chain = IdentityBlockchain::new(&identity, &BcrKeys::new(), 1731593928);
+        println!("{chain:?}");
+        assert!(chain.is_ok());
+        assert!(chain.as_ref().unwrap().is_chain_valid());
+    }
+}

--- a/src/blockchain/identity/mod.rs
+++ b/src/blockchain/identity/mod.rs
@@ -1,0 +1,159 @@
+use super::Result;
+use super::{calculate_hash, Block, Blockchain};
+use crate::service::identity_service::Identity;
+use crate::util::{crypto, rsa, BcrKeys};
+use borsh::to_vec;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum IdentityOpCode {
+    Create,
+    Update,
+    SignPersonBill,
+    CreateCompany,
+    AddSignatory,
+    RemoveSignatory,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct IdentityBlock {
+    pub id: u64,
+    pub hash: String,
+    pub timestamp: i64,
+    pub data: String,
+    pub public_key: String,
+    pub previous_hash: String,
+    pub signature: String,
+    pub op_code: IdentityOpCode,
+}
+
+impl Block for IdentityBlock {
+    type OpCode = IdentityOpCode;
+
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn timestamp(&self) -> i64 {
+        self.timestamp
+    }
+
+    fn op_code(&self) -> &Self::OpCode {
+        &self.op_code
+    }
+
+    fn hash(&self) -> &str {
+        &self.hash
+    }
+
+    fn previous_hash(&self) -> &str {
+        &self.previous_hash
+    }
+
+    fn data(&self) -> &str {
+        &self.data
+    }
+
+    fn signature(&self) -> &str {
+        &self.signature
+    }
+
+    fn public_key(&self) -> &str {
+        &self.public_key
+    }
+}
+
+impl IdentityBlock {
+    pub fn new(
+        id: u64,
+        previous_hash: String,
+        data: String,
+        op_code: IdentityOpCode,
+        keys: &BcrKeys,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let hash = calculate_hash(
+            &id,
+            &previous_hash,
+            &data,
+            &timestamp,
+            &keys.get_public_key(),
+            &op_code,
+        );
+        let signature = crypto::signature(&hash, &keys.get_private_key_string())?;
+
+        Ok(Self {
+            id,
+            hash,
+            timestamp,
+            previous_hash,
+            signature,
+            public_key: keys.get_public_key(),
+            data,
+            op_code,
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IdentityBlockchain {
+    blocks: Vec<IdentityBlock>,
+}
+
+impl Blockchain for IdentityBlockchain {
+    type Block = IdentityBlock;
+
+    fn blocks(&self) -> &Vec<Self::Block> {
+        &self.blocks
+    }
+
+    fn blocks_mut(&mut self) -> &mut Vec<Self::Block> {
+        &mut self.blocks
+    }
+}
+
+impl IdentityBlockchain {
+    /// Creates a new identity chain, encrypting the identity with the public rsa key
+    pub fn new(identity: &Identity, keys: &BcrKeys, timestamp: i64) -> Result<Self> {
+        let identity_bytes = to_vec(&identity)?;
+        let genesis_hash = hex::encode(&identity_bytes);
+
+        let encrypted_data = hex::encode(rsa::encrypt_bytes_with_public_key(
+            &identity_bytes,
+            &identity.public_key_pem,
+        )?);
+
+        let first_block = IdentityBlock::new(
+            1,
+            genesis_hash,
+            encrypted_data,
+            IdentityOpCode::Create,
+            keys,
+            timestamp,
+        )?;
+
+        Ok(Self {
+            blocks: vec![first_block],
+        })
+    }
+
+    /// Creates a blockchain from a list of blocks, ensuring that the resulting chain is valid
+    pub fn create_valid_chain_from_blocks(blocks: Vec<IdentityBlock>) -> Result<Self> {
+        if blocks.is_empty() {
+            return Err(super::Error::BlockchainInvalid);
+        }
+
+        if let Some(first_block) = blocks.first() {
+            if first_block.id != 1 {
+                return Err(super::Error::BlockchainInvalid);
+            }
+        }
+
+        let created = Self { blocks };
+
+        if !created.is_chain_valid() {
+            return Err(super::Error::BlockchainInvalid);
+        }
+        Ok(created)
+    }
+}

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::util::rsa;
+use crate::util::{crypto, rsa};
 use crate::{external, util};
 use log::{error, warn};
 use serde::{de::DeserializeOwned, Serialize};
@@ -29,6 +29,10 @@ pub enum Error {
     /// Errors stemming from cryptography, such as converting keys, encryption and decryption
     #[error("Cryptography error: {0}")]
     Cryptography(#[from] rsa::Error),
+
+    /// Errors stemming from cryptography, such as converting keys, encryption and decryption
+    #[error("Secp256k1Cryptography error: {0}")]
+    Secp256k1Cryptography(#[from] crypto::Error),
 
     /// Errors stemming from decoding
     #[error("Decode error: {0}")]
@@ -76,7 +80,7 @@ pub trait Block {
 
     /// Verifys the block by checking if the signature is correct
     fn verify(&self) -> bool {
-        match rsa::verify_signature(self.hash(), self.signature(), self.public_key()) {
+        match crypto::verify(self.hash(), self.signature(), self.public_key()) {
             Err(e) => {
                 error!("Error while verifying block id {}: {e}", self.id());
                 false

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -7,6 +7,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use std::string::FromUtf8Error;
 
 pub mod bill;
+pub mod identity;
 
 /// Generic result type
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -180,7 +180,7 @@ async fn new(
     identity_store: Arc<dyn IdentityStoreApi>,
     file_upload_store: Arc<dyn FileUploadStoreApi>,
 ) -> Result<(Client, Receiver<Event>, EventLoop)> {
-    if !identity_store.exists().await {
+    if !identity_store.libp2p_credentials_exist().await {
         let keys = BcrKeys::new();
         let p2p_keys = keys.get_libp2p_keys()?;
         let node_id = p2p_keys.public().to_peer_id();

--- a/src/persistence/db/identity.rs
+++ b/src/persistence/db/identity.rs
@@ -1,5 +1,3 @@
-use core::str;
-
 use super::Result;
 use crate::{
     persistence::{identity::IdentityStoreApi, Error},

--- a/src/persistence/db/identity_chain.rs
+++ b/src/persistence/db/identity_chain.rs
@@ -1,0 +1,136 @@
+use super::super::{Error, Result};
+use crate::{
+    blockchain::{
+        identity::{IdentityBlock, IdentityBlockchain, IdentityOpCode},
+        Block,
+    },
+    persistence::identity_chain::IdentityChainStoreApi,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use surrealdb::{engine::any::Any, Surreal};
+
+#[derive(Clone)]
+pub struct SurrealIdentityChainStore {
+    db: Surreal<Any>,
+}
+
+impl SurrealIdentityChainStore {
+    const TABLE: &'static str = "identity_chain";
+
+    pub fn new(db: Surreal<Any>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl IdentityChainStoreApi for SurrealIdentityChainStore {
+    async fn get_chain(&self) -> Result<IdentityBlockchain> {
+        let all_blocks: Vec<IdentityBlockDb> = self.db.select(Self::TABLE).await?;
+
+        if all_blocks.is_empty() {
+            return Err(Error::InvalidIdentityChain(
+                "No identity blocks found".to_string(),
+            ));
+        }
+
+        let mut blocks: Vec<IdentityBlock> = all_blocks
+            .into_iter()
+            .map(|db_block| db_block.into())
+            .collect();
+        // sort the blocks by block id ascending
+        blocks.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // create a new, valid chain from the blocks
+        let chain = IdentityBlockchain::create_valid_chain_from_blocks(blocks)?;
+        Ok(chain)
+    }
+
+    async fn get_latest_block(&self) -> Result<IdentityBlock> {
+        let result: Vec<IdentityBlockDb> = self
+            .db
+            .query("SELECT * FROM type::table($table) ORDER BY block_id DESC LIMIT 1")
+            .bind(("table", Self::TABLE))
+            .await?
+            .take(0)?;
+
+        match result.first() {
+            None => Err(Error::NoIdentityBlock),
+            Some(block) => Ok(block.to_owned().into()),
+        }
+    }
+
+    async fn add_block(&self, block: &IdentityBlock) -> Result<()> {
+        let entity: IdentityBlockDb = block.into();
+        match self.get_latest_block().await {
+            Err(Error::NoIdentityBlock) => {
+                // if there is no latest block, ensure it's a valid first block
+                if block.id == 1 && block.verify() && block.validate_hash() {
+                    let _: Option<IdentityBlockDb> =
+                        self.db.create(Self::TABLE).content(entity).await?;
+                    Ok(())
+                } else {
+                    return Err(Error::AddIdentityBlock(format!(
+                        "First Block validation error: block id: {}",
+                        block.id
+                    )));
+                }
+            }
+            Ok(latest_block) => {
+                // if there is a latest block, ensure it's a valid follow-up block
+                if !block.validate_with_previous(&latest_block) {
+                    return Err(Error::AddIdentityBlock(format!(
+                        "Block validation error: block id: {}, latest block id: {}",
+                        block.id, latest_block.id
+                    )));
+                }
+                let _: Option<IdentityBlockDb> =
+                    self.db.create(Self::TABLE).content(entity).await?;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityBlockDb {
+    pub block_id: u64,
+    pub hash: String,
+    pub previous_hash: String,
+    pub signature: String,
+    pub timestamp: i64,
+    pub public_key: String,
+    pub data: String,
+    pub op_code: IdentityOpCode,
+}
+
+impl From<IdentityBlockDb> for IdentityBlock {
+    fn from(value: IdentityBlockDb) -> Self {
+        Self {
+            id: value.block_id,
+            hash: value.hash,
+            timestamp: value.timestamp,
+            data: value.data,
+            public_key: value.public_key,
+            previous_hash: value.previous_hash,
+            signature: value.signature,
+            op_code: value.op_code,
+        }
+    }
+}
+
+impl From<&IdentityBlock> for IdentityBlockDb {
+    fn from(value: &IdentityBlock) -> Self {
+        Self {
+            block_id: value.id,
+            hash: value.hash.clone(),
+            previous_hash: value.previous_hash.clone(),
+            signature: value.signature.clone(),
+            timestamp: value.timestamp,
+            public_key: value.public_key.clone(),
+            data: value.data.clone(),
+            op_code: value.op_code.clone(),
+        }
+    }
+}

--- a/src/persistence/db/mod.rs
+++ b/src/persistence/db/mod.rs
@@ -8,6 +8,7 @@ use surrealdb::{
 pub mod company;
 pub mod contact;
 pub mod identity;
+pub mod identity_chain;
 pub mod nostr_event_offset;
 
 /// Configuration for the SurrealDB connection string, namespace and

--- a/src/persistence/identity.rs
+++ b/src/persistence/identity.rs
@@ -15,7 +15,6 @@ pub trait IdentityStoreApi: Send + Sync {
     /// Checks if the identity has been created
     async fn exists(&self) -> bool;
     /// Checks if the libp2p credentials for the identity have been created
-    #[allow(dead_code)]
     async fn libp2p_credentials_exist(&self) -> bool;
     /// Saves the given identity
     async fn save(&self, identity: &Identity) -> Result<()>;

--- a/src/persistence/identity_chain.rs
+++ b/src/persistence/identity_chain.rs
@@ -1,0 +1,18 @@
+use super::Result;
+use crate::blockchain::identity::{IdentityBlock, IdentityBlockchain};
+use async_trait::async_trait;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait IdentityChainStoreApi: Send + Sync {
+    /// Gets the whole chain
+    #[allow(dead_code)]
+    async fn get_chain(&self) -> Result<IdentityBlockchain>;
+    /// Gets the latest block of the chain
+    async fn get_latest_block(&self) -> Result<IdentityBlock>;
+    /// Adds the block to the chain
+    async fn add_block(&self, block: &IdentityBlock) -> Result<()>;
+}

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -681,7 +681,6 @@ impl BillServiceApi for BillService {
 
         let chain = BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             public_data_drawer,
             drawer.key_pair,
             public_key_pem,
@@ -1125,7 +1124,6 @@ pub mod test {
         let bill = bill.unwrap_or(get_baseline_bill("some name"));
         BillBlockchain::new(
             &bill,
-            BillOpCode::Issue,
             IdentityPublicData::new_empty(),
             get_baseline_identity().key_pair,
             TEST_PUB_KEY.to_owned(),

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -295,9 +295,8 @@ impl BillService {
             last_block.id + 1,
             last_block.hash.clone(),
             data_for_new_block_encrypted_in_string_format,
-            identity.identity.public_key_pem,
             operation_code,
-            identity.identity.private_key_pem,
+            identity.key_pair,
             timestamp,
         )?;
 
@@ -684,8 +683,7 @@ impl BillServiceApi for BillService {
             &bill,
             BillOpCode::Issue,
             public_data_drawer,
-            drawer.identity.public_key_pem,
-            drawer.identity.private_key_pem,
+            drawer.key_pair,
             public_key_pem,
             timestamp,
         )?;
@@ -1129,8 +1127,7 @@ pub mod test {
             &bill,
             BillOpCode::Issue,
             IdentityPublicData::new_empty(),
-            TEST_PUB_KEY.to_owned(),
-            TEST_PRIVATE_KEY.to_owned(),
+            get_baseline_identity().key_pair,
             TEST_PUB_KEY.to_owned(),
             1731593928,
         )
@@ -1628,9 +1625,8 @@ pub mod test {
                 123456,
                 "prevhash".to_string(),
                 "hash".to_string(),
-                TEST_PUB_KEY.to_owned(),
                 BillOpCode::Accept,
-                TEST_PRIVATE_KEY.to_owned(),
+                identity.key_pair,
                 1731593928,
             )
             .unwrap(),

--- a/src/web/handlers/identity.rs
+++ b/src/web/handlers/identity.rs
@@ -1,3 +1,4 @@
+use crate::external;
 use crate::service::{self, Result};
 use crate::web::data::{ChangeIdentityPayload, IdentityPayload, NodeId};
 use crate::{service::identity_service::Identity, service::ServiceContext};
@@ -28,6 +29,7 @@ pub async fn create_identity(
     identity_payload: Json<IdentityPayload>,
 ) -> Result<Status> {
     let identity = identity_payload.into_inner();
+    let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
     state
         .identity_service
         .create_identity(
@@ -38,6 +40,7 @@ pub async fn create_identity(
             identity.country_of_birth,
             identity.email,
             identity.postal_address,
+            timestamp,
         )
         .await?;
     Ok(Status::Ok)


### PR DESCRIPTION
## 📝 Description

Draft for feedback on identity chain persistence structure. Tests are missing. The implementation of the different identity chain use-cases will be in a different PR.

This implements two things:
1. It changes the signature/verification mechanism within the blockchain implementations to use the secp256k1 keys, instead of RSA
2. It implements a persistence structure for storing the identity blockchain

Relates to #140 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Sign/Verify using Secp256k1
  - Persistence structure for identity blockchain

---

## 💡 How to Test

Run tests.
Upon identity creation, the identity blockchain should have been created in SurrealDB

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #140

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
