### PR TITLE
Add identity chain actions, switch from hex to base58, switch to borsh for signature, refactor identity chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,11 +1115,11 @@ dependencies = [
  "bitcoin 0.32.3",
  "borsh",
  "borsh-derive",
+ "bs58 0.5.1",
  "chrono",
  "clap",
  "env_logger",
  "futures",
- "hex",
  "hf",
  "infer",
  "lazy_static",
@@ -1288,6 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "sha2 0.10.8",
+ "tinyvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ rocket_dyn_templates = { version = "0.2.0", features = ["handlebars"] }
 open = "5.3.0"
 serde_json = "1.0.129"
 serde = { version = "1.0.210", features = ["derive"] }
-hex = "0.4.3"
 log = "0.4.22"
 futures = "0.3.31"
 bitcoin = { version = "0.32.3", features = ["rand", "rand-std"] }
@@ -63,6 +62,7 @@ uuid = { version = "1.11.0", features = ["v4"] }
 infer = { version = "0.16", default-features = false }
 surrealdb = "2"
 lazy_static = "1.5.0"
+bs58 = "0.5.1"
 
 [dev-dependencies]
 mockall = "0.13.0"

--- a/src/blockchain/bill/block.rs
+++ b/src/blockchain/bill/block.rs
@@ -104,7 +104,7 @@ impl BillBlock {
             &timestamp,
             &keys.get_public_key(),
             &operation_code,
-        );
+        )?;
         let signature = crypto::signature(&hash, &keys.get_private_key_string())?;
 
         Ok(Self {
@@ -128,7 +128,7 @@ impl BillBlock {
 
     /// Decrypts the block data using the bill's private key, returning the raw bytes
     pub fn get_decrypted_block_bytes(&self, bill_keys: &BillKeys) -> Result<Vec<u8>> {
-        let bytes = hex::decode(&self.data)?;
+        let bytes = util::base58_decode(&self.data)?;
         let decrypted_bytes =
             rsa::decrypt_bytes_with_private_key(&bytes, &bill_keys.private_key_pem)?;
         Ok(decrypted_bytes)
@@ -167,7 +167,7 @@ impl BillBlock {
             Endorse => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let endorsee: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let endorsee: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ENDORSED_TO).ok_or(
                         Error::InvalidBlockdata(String::from("Endorse: No endorsee found")),
                     )?,
@@ -177,7 +177,7 @@ impl BillBlock {
                     nodes.insert(endorsee_node_id);
                 }
 
-                let endorser: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let endorser: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ENDORSED_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Endorse: No endorser found")),
                     )?,
@@ -190,7 +190,7 @@ impl BillBlock {
             Mint => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let mint: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let mint: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ENDORSED_TO)
                         .ok_or(Error::InvalidBlockdata(String::from("Mint: No mint found")))?,
                 )?)?;
@@ -199,7 +199,7 @@ impl BillBlock {
                     nodes.insert(mint_node_id);
                 }
 
-                let minter: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let minter: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ENDORSED_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Mint: No minter found")),
                     )?,
@@ -212,7 +212,7 @@ impl BillBlock {
             RequestToAccept => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let requester: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let requester: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, REQ_TO_ACCEPT_BY).ok_or(
                         Error::InvalidBlockdata(String::from(
                             "Request to accept: No requester found",
@@ -227,7 +227,7 @@ impl BillBlock {
             Accept => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let accepter: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let accepter: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ACCEPTED_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Accept: No accepter found")),
                     )?,
@@ -240,7 +240,7 @@ impl BillBlock {
             RequestToPay => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let requester: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let requester: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, REQ_TO_PAY_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Request to Pay: No requester found")),
                     )?,
@@ -253,7 +253,7 @@ impl BillBlock {
             Sell => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let buyer: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let buyer: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, SOLD_TO).ok_or(
                         Error::InvalidBlockdata(String::from("Sell: No buyer found")),
                     )?,
@@ -263,7 +263,7 @@ impl BillBlock {
                     nodes.insert(buyer_node_id);
                 }
 
-                let seller: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let seller: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, SOLD_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Sell: No seller found")),
                     )?,
@@ -310,7 +310,7 @@ impl BillBlock {
             Endorse => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let endorser: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let endorser: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ENDORSED_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Endorse: No endorser found")),
                     )?,
@@ -321,7 +321,7 @@ impl BillBlock {
             Mint => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let minter: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let minter: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ENDORSED_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Mint: No minter found")),
                     )?,
@@ -333,7 +333,7 @@ impl BillBlock {
                 let time_of_request_to_accept = util::date::seconds(self.timestamp);
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let requester: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let requester: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, REQ_TO_ACCEPT_BY).ok_or(
                         Error::InvalidBlockdata(String::from(
                             "Request to accept: No requester found",
@@ -350,7 +350,7 @@ impl BillBlock {
                 let time_of_accept = util::date::seconds(self.timestamp);
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let accepter: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let accepter: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, ACCEPTED_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Accept: No accepter found")),
                     )?,
@@ -365,7 +365,7 @@ impl BillBlock {
                 let time_of_request_to_pay = util::date::seconds(self.timestamp);
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let requester: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let requester: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, REQ_TO_PAY_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Request to pay: No requester found")),
                     )?,
@@ -379,7 +379,7 @@ impl BillBlock {
             Sell => {
                 let block_data_decrypted = self.get_decrypted_block_data(bill_keys)?;
 
-                let seller: IdentityPublicData = serde_json::from_slice(&hex::decode(
+                let seller: IdentityPublicData = serde_json::from_slice(&util::base58_decode(
                     &extract_after_phrase(&block_data_decrypted, SOLD_BY).ok_or(
                         Error::InvalidBlockdata(String::from("Sell: No seller found")),
                     )?,
@@ -425,8 +425,8 @@ mod test {
         bill.payee = drawer.clone();
         bill.drawee = payer;
 
-        let hashed_bill = hex::encode(
-            rsa::encrypt_bytes_with_public_key(&to_vec(&bill).unwrap(), TEST_PUB_KEY).unwrap(),
+        let hashed_bill = util::base58_encode(
+            &rsa::encrypt_bytes_with_public_key(&to_vec(&bill).unwrap(), TEST_PUB_KEY).unwrap(),
         );
 
         let block = BillBlock::new(
@@ -453,8 +453,8 @@ mod test {
         drawer.name = "bill".to_string();
         bill.drawer = drawer.clone();
 
-        let hashed_bill = hex::encode(
-            rsa::encrypt_bytes_with_public_key(&to_vec(&bill).unwrap(), TEST_PUB_KEY).unwrap(),
+        let hashed_bill = util::base58_encode(
+            &rsa::encrypt_bytes_with_public_key(&to_vec(&bill).unwrap(), TEST_PUB_KEY).unwrap(),
         );
 
         let block = BillBlock::new(
@@ -482,8 +482,8 @@ mod test {
         let mut endorser = IdentityPublicData::new_empty();
         let endorser_peer_id = PeerId::random().to_string();
         endorser.peer_id = endorser_peer_id.clone();
-        let hashed_endorsee = hex::encode(serde_json::to_vec(&endorsee).unwrap());
-        let hashed_endorser = hex::encode(serde_json::to_vec(&endorser).unwrap());
+        let hashed_endorsee = util::base58_encode(&serde_json::to_vec(&endorsee).unwrap());
+        let hashed_endorser = util::base58_encode(&serde_json::to_vec(&endorser).unwrap());
 
         let data = format!(
             "{}{}{}{}",
@@ -493,7 +493,9 @@ mod test {
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Endorse,
             BcrKeys::new(),
             1731593928,
@@ -512,8 +514,8 @@ mod test {
         let mut endorser = IdentityPublicData::new_empty();
         endorser.name = "bill".to_string();
         endorser.postal_address = "some street 1".to_string();
-        let hashed_endorsee = hex::encode(serde_json::to_vec(&endorsee).unwrap());
-        let hashed_endorser = hex::encode(serde_json::to_vec(&endorser).unwrap());
+        let hashed_endorsee = util::base58_encode(&serde_json::to_vec(&endorsee).unwrap());
+        let hashed_endorser = util::base58_encode(&serde_json::to_vec(&endorser).unwrap());
 
         let data = format!(
             "{}{}{}{}",
@@ -523,7 +525,9 @@ mod test {
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Endorse,
             BcrKeys::new(),
             1731593928,
@@ -542,8 +546,8 @@ mod test {
         let mut minter = IdentityPublicData::new_empty();
         let minter_peer_id = PeerId::random().to_string();
         minter.peer_id = minter_peer_id.clone();
-        let hashed_mint = hex::encode(serde_json::to_vec(&mint).unwrap());
-        let hashed_minter = hex::encode(serde_json::to_vec(&minter).unwrap());
+        let hashed_mint = util::base58_encode(&serde_json::to_vec(&mint).unwrap());
+        let hashed_minter = util::base58_encode(&serde_json::to_vec(&minter).unwrap());
 
         let data = format!(
             "{}{}{}{}",
@@ -553,7 +557,9 @@ mod test {
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Mint,
             BcrKeys::new(),
             1731593928,
@@ -572,8 +578,8 @@ mod test {
         let mut minter = IdentityPublicData::new_empty();
         minter.name = "bill".to_string();
         minter.postal_address = "some street 1".to_string();
-        let hashed_endorsee = hex::encode(serde_json::to_vec(&mint).unwrap());
-        let hashed_endorser = hex::encode(serde_json::to_vec(&minter).unwrap());
+        let hashed_endorsee = util::base58_encode(&serde_json::to_vec(&mint).unwrap());
+        let hashed_endorser = util::base58_encode(&serde_json::to_vec(&minter).unwrap());
 
         let data = format!(
             "{}{}{}{}",
@@ -583,7 +589,9 @@ mod test {
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Mint,
             BcrKeys::new(),
             1731593928,
@@ -599,14 +607,16 @@ mod test {
         let mut requester = IdentityPublicData::new_empty();
         let peer_id = PeerId::random().to_string();
         requester.peer_id = peer_id.clone();
-        let hashed_requester = hex::encode(serde_json::to_vec(&requester).unwrap());
+        let hashed_requester = util::base58_encode(&serde_json::to_vec(&requester).unwrap());
 
         let data = format!("{}{}", REQ_TO_ACCEPT_BY, &hashed_requester);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::RequestToAccept,
             BcrKeys::new(),
             1731593928,
@@ -623,14 +633,16 @@ mod test {
         let mut requester = IdentityPublicData::new_empty();
         requester.name = "bill".to_string();
         requester.postal_address = "some street 1".to_string();
-        let hashed_requester = hex::encode(serde_json::to_vec(&requester).unwrap());
+        let hashed_requester = util::base58_encode(&serde_json::to_vec(&requester).unwrap());
 
         let data = format!("{}{}", REQ_TO_ACCEPT_BY, &hashed_requester);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::RequestToAccept,
             BcrKeys::new(),
             1731593928,
@@ -649,14 +661,16 @@ mod test {
         let mut accepter = IdentityPublicData::new_empty();
         let peer_id = PeerId::random().to_string();
         accepter.peer_id = peer_id.clone();
-        let hashed_accepter = hex::encode(serde_json::to_vec(&accepter).unwrap());
+        let hashed_accepter = util::base58_encode(&serde_json::to_vec(&accepter).unwrap());
 
         let data = format!("{}{}", ACCEPTED_BY, &hashed_accepter);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Accept,
             BcrKeys::new(),
             1731593928,
@@ -673,14 +687,16 @@ mod test {
         let mut accepter = IdentityPublicData::new_empty();
         accepter.name = "bill".to_string();
         accepter.postal_address = "some street 1".to_string();
-        let hashed_accepter = hex::encode(serde_json::to_vec(&accepter).unwrap());
+        let hashed_accepter = util::base58_encode(&serde_json::to_vec(&accepter).unwrap());
 
         let data = format!("{}{}", ACCEPTED_BY, &hashed_accepter);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Accept,
             BcrKeys::new(),
             1731593928,
@@ -699,7 +715,7 @@ mod test {
         let mut accepter = IdentityPublicData::new_empty();
         let peer_id = PeerId::random().to_string();
         accepter.peer_id = peer_id.clone();
-        let hashed_accepter = hex::encode(serde_json::to_vec(&accepter).unwrap());
+        let hashed_accepter = util::base58_encode(&serde_json::to_vec(&accepter).unwrap());
 
         let data = format!("{}{}", ACCEPTED_BY, &hashed_accepter);
 
@@ -707,7 +723,7 @@ mod test {
             1,
             String::from("prevhash"),
             // not encrypted
-            hex::encode(data.as_bytes()),
+            util::base58_encode(data.as_bytes()),
             BillOpCode::Accept,
             BcrKeys::new(),
             1731593928,
@@ -722,8 +738,8 @@ mod test {
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(
-                rsa::encrypt_bytes_with_public_key(
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(
                     // invalid data
                     "some data".to_string().as_bytes(),
                     TEST_PUB_KEY,
@@ -744,14 +760,16 @@ mod test {
         let mut requester = IdentityPublicData::new_empty();
         let peer_id = PeerId::random().to_string();
         requester.peer_id = peer_id.clone();
-        let hashed_requester = hex::encode(serde_json::to_vec(&requester).unwrap());
+        let hashed_requester = util::base58_encode(&serde_json::to_vec(&requester).unwrap());
 
         let data = format!("{}{}", REQ_TO_PAY_BY, &hashed_requester);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::RequestToPay,
             BcrKeys::new(),
             1731593928,
@@ -768,14 +786,16 @@ mod test {
         let mut requester = IdentityPublicData::new_empty();
         requester.name = "bill".to_string();
         requester.postal_address = "some street 1".to_string();
-        let hashed_requester = hex::encode(serde_json::to_vec(&requester).unwrap());
+        let hashed_requester = util::base58_encode(&serde_json::to_vec(&requester).unwrap());
 
         let data = format!("{}{}", REQ_TO_PAY_BY, &hashed_requester);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::RequestToPay,
             BcrKeys::new(),
             1731593928,
@@ -797,15 +817,17 @@ mod test {
         let mut seller = IdentityPublicData::new_empty();
         let endorser_peer_id = PeerId::random().to_string();
         seller.peer_id = endorser_peer_id.clone();
-        let hashed_buyer = hex::encode(serde_json::to_vec(&buyer).unwrap());
-        let hashed_seller = hex::encode(serde_json::to_vec(&seller).unwrap());
+        let hashed_buyer = util::base58_encode(&serde_json::to_vec(&buyer).unwrap());
+        let hashed_seller = util::base58_encode(&serde_json::to_vec(&seller).unwrap());
 
         let data = format!("{}{}{}{}", SOLD_TO, &hashed_buyer, SOLD_BY, &hashed_seller);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Sell,
             BcrKeys::new(),
             1731593928,
@@ -823,14 +845,16 @@ mod test {
         let mut seller = IdentityPublicData::new_empty();
         seller.name = "bill".to_string();
         seller.postal_address = "some street 1".to_string();
-        let hashed_seller = hex::encode(serde_json::to_vec(&seller).unwrap());
+        let hashed_seller = util::base58_encode(&serde_json::to_vec(&seller).unwrap());
 
         let data = format!("{}{}", SOLD_BY, &hashed_seller);
 
         let block = BillBlock::new(
             1,
             String::from("prevhash"),
-            hex::encode(rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap()),
+            util::base58_encode(
+                &rsa::encrypt_bytes_with_public_key(data.as_bytes(), TEST_PUB_KEY).unwrap(),
+            ),
             BillOpCode::Sell,
             BcrKeys::new(),
             1731593928,

--- a/src/blockchain/bill/mod.rs
+++ b/src/blockchain/bill/mod.rs
@@ -1,3 +1,4 @@
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use super::{Blockchain, Result};
@@ -10,7 +11,7 @@ mod chain;
 pub use block::BillBlock;
 pub use chain::BillBlockchain;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum BillOpCode {
     Issue,
     Accept,

--- a/src/blockchain/identity/mod.rs
+++ b/src/blockchain/identity/mod.rs
@@ -1,11 +1,13 @@
+use super::bill::BillOpCode;
 use super::Result;
 use super::{calculate_hash, Block, Blockchain};
 use crate::service::identity_service::Identity;
-use crate::util::{crypto, rsa, BcrKeys};
+use crate::util::{self, crypto, rsa, BcrKeys};
 use borsh::to_vec;
+use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(BorshSerialize, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum IdentityOpCode {
     Create,
     Update,
@@ -25,6 +27,71 @@ pub struct IdentityBlock {
     pub previous_hash: String,
     pub signature: String,
     pub op_code: IdentityOpCode,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+pub struct IdentityCreateBlockData {
+    pub name: String,
+    pub company: String,
+    pub date_of_birth: String,
+    pub city_of_birth: String,
+    pub country_of_birth: String,
+    pub email: String,
+    pub postal_address: String,
+    pub nostr_relay: Option<String>,
+}
+
+impl From<Identity> for IdentityCreateBlockData {
+    fn from(value: Identity) -> Self {
+        Self {
+            name: value.name,
+            company: value.company,
+            date_of_birth: value.date_of_birth,
+            city_of_birth: value.city_of_birth,
+            country_of_birth: value.country_of_birth,
+            email: value.email,
+            postal_address: value.postal_address,
+            nostr_relay: value.nostr_relay,
+        }
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+pub struct IdentityUpdateBlockData {
+    pub name: Option<String>,
+    pub company: Option<String>,
+    pub email: Option<String>,
+    pub postal_address: Option<String>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+pub struct IdentitySignPersonBillBlockData {
+    pub bill_id: String,
+    pub block_id: u64,
+    pub block_hash: String,
+    pub operation: BillOpCode,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+pub struct IdentityCreateCompanyBlockData {
+    pub company_id: String,
+    pub block_hash: String,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+pub struct IdentityAddSignatoryBlockData {
+    pub company_id: String,
+    pub block_id: u64,
+    pub block_hash: String,
+    pub signatory: String,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq)]
+pub struct IdentityRemoveSignatoryBlockData {
+    pub company_id: String,
+    pub block_id: u64,
+    pub block_hash: String,
+    pub signatory: String,
 }
 
 impl Block for IdentityBlock {
@@ -64,7 +131,7 @@ impl Block for IdentityBlock {
 }
 
 impl IdentityBlock {
-    pub fn new(
+    fn new(
         id: u64,
         previous_hash: String,
         data: String,
@@ -79,7 +146,7 @@ impl IdentityBlock {
             &timestamp,
             &keys.get_public_key(),
             &op_code,
-        );
+        )?;
         let signature = crypto::signature(&hash, &keys.get_private_key_string())?;
 
         Ok(Self {
@@ -92,6 +159,151 @@ impl IdentityBlock {
             data,
             op_code,
         })
+    }
+
+    pub fn create_block_for_create(
+        id: u64,
+        previous_hash: String,
+        identity: &IdentityCreateBlockData,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let identity_bytes = to_vec(identity)?;
+
+        let encrypted_data = util::base58_encode(&rsa::encrypt_bytes_with_public_key(
+            &identity_bytes,
+            rsa_public_key_pem,
+        )?);
+
+        Self::new(
+            id,
+            previous_hash,
+            encrypted_data,
+            IdentityOpCode::Create,
+            keys,
+            timestamp,
+        )
+    }
+
+    pub fn create_block_for_update(
+        previous_block: &Self,
+        data: &IdentityUpdateBlockData,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let block = Self::encrypt_data_create_block_and_validate(
+            previous_block,
+            data,
+            keys,
+            rsa_public_key_pem,
+            timestamp,
+            IdentityOpCode::Update,
+        )?;
+        Ok(block)
+    }
+
+    pub fn create_block_for_sign_person_bill(
+        previous_block: &Self,
+        data: &IdentitySignPersonBillBlockData,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let block = Self::encrypt_data_create_block_and_validate(
+            previous_block,
+            data,
+            keys,
+            rsa_public_key_pem,
+            timestamp,
+            IdentityOpCode::SignPersonBill,
+        )?;
+        Ok(block)
+    }
+
+    pub fn create_block_for_create_company(
+        previous_block: &Self,
+        data: &IdentityCreateCompanyBlockData,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let block = Self::encrypt_data_create_block_and_validate(
+            previous_block,
+            data,
+            keys,
+            rsa_public_key_pem,
+            timestamp,
+            IdentityOpCode::CreateCompany,
+        )?;
+        Ok(block)
+    }
+
+    pub fn create_block_for_add_signatory(
+        previous_block: &Self,
+        data: &IdentityAddSignatoryBlockData,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let block = Self::encrypt_data_create_block_and_validate(
+            previous_block,
+            data,
+            keys,
+            rsa_public_key_pem,
+            timestamp,
+            IdentityOpCode::AddSignatory,
+        )?;
+        Ok(block)
+    }
+
+    pub fn create_block_for_remove_signatory(
+        previous_block: &Self,
+        data: &IdentityRemoveSignatoryBlockData,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let block = Self::encrypt_data_create_block_and_validate(
+            previous_block,
+            data,
+            keys,
+            rsa_public_key_pem,
+            timestamp,
+            IdentityOpCode::RemoveSignatory,
+        )?;
+        Ok(block)
+    }
+
+    fn encrypt_data_create_block_and_validate<T: borsh::BorshSerialize>(
+        previous_block: &Self,
+        data: &T,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+        op_code: IdentityOpCode,
+    ) -> Result<Self> {
+        let bytes = to_vec(&data)?;
+
+        let encrypted_data = util::base58_encode(&rsa::encrypt_bytes_with_public_key(
+            &bytes,
+            rsa_public_key_pem,
+        )?);
+
+        let new_block = Self::new(
+            previous_block.id + 1,
+            previous_block.hash.clone(),
+            encrypted_data,
+            op_code,
+            keys,
+            timestamp,
+        )?;
+
+        if !new_block.validate_with_previous(previous_block) {
+            return Err(super::Error::BlockInvalid);
+        }
+        Ok(new_block)
     }
 }
 
@@ -114,21 +326,21 @@ impl Blockchain for IdentityBlockchain {
 
 impl IdentityBlockchain {
     /// Creates a new identity chain, encrypting the identity with the public rsa key
-    pub fn new(identity: &Identity, keys: &BcrKeys, timestamp: i64) -> Result<Self> {
-        let identity_bytes = to_vec(&identity)?;
-        let genesis_hash = hex::encode(&identity_bytes);
+    pub fn new(
+        identity: &IdentityCreateBlockData,
+        node_id: &str,
+        keys: &BcrKeys,
+        rsa_public_key_pem: &str,
+        timestamp: i64,
+    ) -> Result<Self> {
+        let genesis_hash = util::base58_encode(node_id.as_bytes());
 
-        let encrypted_data = hex::encode(rsa::encrypt_bytes_with_public_key(
-            &identity_bytes,
-            &identity.public_key_pem,
-        )?);
-
-        let first_block = IdentityBlock::new(
+        let first_block = IdentityBlock::create_block_for_create(
             1,
             genesis_hash,
-            encrypted_data,
-            IdentityOpCode::Create,
+            identity,
             keys,
+            rsa_public_key_pem,
             timestamp,
         )?;
 
@@ -136,40 +348,26 @@ impl IdentityBlockchain {
             blocks: vec![first_block],
         })
     }
-
-    /// Creates a blockchain from a list of blocks, ensuring that the resulting chain is valid
-    pub fn create_valid_chain_from_blocks(blocks: Vec<IdentityBlock>) -> Result<Self> {
-        if blocks.is_empty() {
-            return Err(super::Error::BlockchainInvalid);
-        }
-
-        if let Some(first_block) = blocks.first() {
-            if first_block.id != 1 {
-                return Err(super::Error::BlockchainInvalid);
-            }
-        }
-
-        let created = Self { blocks };
-
-        if !created.is_chain_valid() {
-            return Err(super::Error::BlockchainInvalid);
-        }
-        Ok(created)
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::tests::test::TEST_PUB_KEY;
+    use libp2p::PeerId;
 
     #[test]
     fn create_and_check_validity() {
         let mut identity = Identity::new_empty();
         identity.public_key_pem = TEST_PUB_KEY.to_string();
 
-        let chain = IdentityBlockchain::new(&identity, &BcrKeys::new(), 1731593928);
-        println!("{chain:?}");
+        let chain = IdentityBlockchain::new(
+            &identity.into(),
+            &PeerId::random().to_string(),
+            &BcrKeys::new(),
+            TEST_PUB_KEY,
+            1731593928,
+        );
         assert!(chain.is_ok());
         assert!(chain.as_ref().unwrap().is_chain_valid());
     }

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -3036,7 +3036,6 @@ mod test {
         )
         .check_new_bills()
         .await;
-        println!("{result:?}");
         assert!(result.is_ok());
     }
 

--- a/src/persistence/identity_chain.rs
+++ b/src/persistence/identity_chain.rs
@@ -1,5 +1,5 @@
 use super::Result;
-use crate::blockchain::identity::{IdentityBlock, IdentityBlockchain};
+use crate::blockchain::identity::IdentityBlock;
 use async_trait::async_trait;
 
 #[cfg(test)]
@@ -8,9 +8,6 @@ use mockall::automock;
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait IdentityChainStoreApi: Send + Sync {
-    /// Gets the whole chain
-    #[allow(dead_code)]
-    async fn get_chain(&self) -> Result<IdentityBlockchain>;
     /// Gets the latest block of the chain
     async fn get_latest_block(&self) -> Result<IdentityBlock>;
     /// Adds the block to the chain

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -1,5 +1,10 @@
 use super::Result;
+use crate::blockchain::identity::{
+    IdentityAddSignatoryBlockData, IdentityBlock, IdentityCreateCompanyBlockData,
+    IdentityRemoveSignatoryBlockData,
+};
 use crate::persistence::company::CompanyStoreApi;
+use crate::persistence::identity_chain::IdentityChainStoreApi;
 use crate::CONFIG;
 use crate::{
     error,
@@ -33,6 +38,7 @@ pub trait CompanyServiceApi: Send + Sync {
         registration_date: String,
         proof_of_registration_file_upload_id: Option<String>,
         logo_file_upload_id: Option<String>,
+        timestamp: i64,
     ) -> Result<CompanyToReturn>;
 
     /// Changes the given company fields for the given company, if they are set
@@ -46,10 +52,22 @@ pub trait CompanyServiceApi: Send + Sync {
     ) -> Result<()>;
 
     /// Adds another signatory to the given company
-    async fn add_signatory(&self, id: &str, signatory_node_id: String) -> Result<()>;
+    async fn add_signatory(
+        &self,
+        id: &str,
+        signatory_node_id: String,
+
+        timestamp: i64,
+    ) -> Result<()>;
 
     /// Removes a signatory from the given company
-    async fn remove_signatory(&self, id: &str, signatory_node_id: String) -> Result<()>;
+    async fn remove_signatory(
+        &self,
+        id: &str,
+        signatory_node_id: String,
+
+        timestamp: i64,
+    ) -> Result<()>;
 
     /// Encrypts and saves the given uploaded file, returning the file name, as well as the hash of
     /// the unencrypted file
@@ -77,6 +95,7 @@ pub struct CompanyService {
     file_upload_store: Arc<dyn FileUploadStoreApi>,
     identity_store: Arc<dyn IdentityStoreApi>,
     contact_store: Arc<dyn ContactStoreApi>,
+    identity_blockchain_store: Arc<dyn IdentityChainStoreApi>,
 }
 
 impl CompanyService {
@@ -85,12 +104,14 @@ impl CompanyService {
         file_upload_store: Arc<dyn FileUploadStoreApi>,
         identity_store: Arc<dyn IdentityStoreApi>,
         contact_store: Arc<dyn ContactStoreApi>,
+        identity_blockchain_store: Arc<dyn IdentityChainStoreApi>,
     ) -> Self {
         Self {
             store,
             file_upload_store,
             identity_store,
             contact_store,
+            identity_blockchain_store,
         }
     }
 
@@ -151,6 +172,7 @@ impl CompanyServiceApi for CompanyService {
         registration_date: String,
         proof_of_registration_file_upload_id: Option<String>,
         logo_file_upload_id: Option<String>,
+        timestamp: i64,
     ) -> Result<CompanyToReturn> {
         let (private_key, public_key) = util::create_bitcoin_keypair(CONFIG.bitcoin_network());
         let id = util::sha256_hash(&public_key.to_bytes());
@@ -160,19 +182,22 @@ impl CompanyServiceApi for CompanyService {
             public_key: public_key.to_string(),
         };
 
-        let identity = self.identity_store.get().await?;
-        let node_id = self.identity_store.get_node_id().await?;
+        let full_identity = self.identity_store.get_full().await?;
 
         let proof_of_registration_file = self
             .process_upload_file(
                 &proof_of_registration_file_upload_id,
                 &id,
-                &identity.public_key_pem,
+                &full_identity.identity.public_key_pem,
             )
             .await?;
 
         let logo_file = self
-            .process_upload_file(&logo_file_upload_id, &id, &identity.public_key_pem)
+            .process_upload_file(
+                &logo_file_upload_id,
+                &id,
+                &full_identity.identity.public_key_pem,
+            )
             .await?;
 
         self.store.save_key_pair(&id, &company_keys).await?;
@@ -186,9 +211,23 @@ impl CompanyServiceApi for CompanyService {
             registration_date,
             proof_of_registration_file,
             logo_file,
-            signatories: vec![node_id.to_string()], // add caller as signatory
+            signatories: vec![full_identity.peer_id.to_string()], // add caller as signatory
         };
         self.store.insert(&id, &company).await?;
+
+        let previous_block = self.identity_blockchain_store.get_latest_block().await?;
+        let new_block = IdentityBlock::create_block_for_create_company(
+            &previous_block,
+            &IdentityCreateCompanyBlockData {
+                company_id: id.clone(),
+                block_hash: "TODO_COMPANY_BLOCK_HASH".to_string(), // TODO: use actual hash once we
+                                                                   // have company chain
+            },
+            &full_identity.key_pair,
+            &full_identity.identity.public_key_pem,
+            timestamp,
+        )?;
+        self.identity_blockchain_store.add_block(&new_block).await?;
 
         // clean up temporary file uploads, if there are any, logging any errors
         for upload_id in [proof_of_registration_file_upload_id, logo_file_upload_id]
@@ -259,12 +298,18 @@ impl CompanyServiceApi for CompanyService {
         Ok(())
     }
 
-    async fn add_signatory(&self, id: &str, signatory_node_id: String) -> Result<()> {
+    async fn add_signatory(
+        &self,
+        id: &str,
+        signatory_node_id: String,
+        timestamp: i64,
+    ) -> Result<()> {
         if !self.store.exists(id).await {
             return Err(super::Error::Validation(format!(
                 "No company with id: {id} found.",
             )));
         }
+        let full_identity = self.identity_store.get_full().await?;
         let contacts = self.contact_store.get_map().await?;
         let is_in_contacts = contacts
             .iter()
@@ -281,19 +326,41 @@ impl CompanyServiceApi for CompanyService {
                 "Node Id {signatory_node_id} is already a signatory.",
             )));
         }
-        company.signatories.push(signatory_node_id);
+        company.signatories.push(signatory_node_id.clone());
         self.store.update(id, &company).await?;
+
+        let previous_block = self.identity_blockchain_store.get_latest_block().await?;
+        // TODO: use actual hash once we have company chain
+        let new_block = IdentityBlock::create_block_for_add_signatory(
+            &previous_block,
+            &IdentityAddSignatoryBlockData {
+                company_id: id.to_owned(),
+                block_hash: "TODO_COMPANY_BLOCK_HASH".to_string(),
+                block_id: 9999,
+                signatory: signatory_node_id,
+            },
+            &full_identity.key_pair,
+            &full_identity.identity.public_key_pem,
+            timestamp,
+        )?;
+        self.identity_blockchain_store.add_block(&new_block).await?;
 
         Ok(())
     }
 
-    async fn remove_signatory(&self, id: &str, signatory_node_id: String) -> Result<()> {
+    async fn remove_signatory(
+        &self,
+        id: &str,
+        signatory_node_id: String,
+        timestamp: i64,
+    ) -> Result<()> {
         if !self.store.exists(id).await {
             return Err(super::Error::Validation(format!(
                 "No company with id: {id} found.",
             )));
         }
 
+        let full_identity = self.identity_store.get_full().await?;
         let mut company = self.store.get(id).await?;
         if company.signatories.len() == 1 {
             return Err(super::Error::Validation(String::from(
@@ -306,16 +373,30 @@ impl CompanyServiceApi for CompanyService {
             )));
         }
 
-        let node_id = self.identity_store.get_node_id().await?;
-
         company.signatories.retain(|i| i != &signatory_node_id);
         self.store.update(id, &company).await?;
 
-        if node_id.to_string() == signatory_node_id {
+        if full_identity.peer_id.to_string() == signatory_node_id {
             info!("Removing self from company {id}");
             let _ = self.file_upload_store.delete_attached_files(id).await;
             self.store.remove(id).await?;
         }
+
+        let previous_block = self.identity_blockchain_store.get_latest_block().await?;
+        // TODO: use actual hash once we have company chain
+        let new_block = IdentityBlock::create_block_for_remove_signatory(
+            &previous_block,
+            &IdentityRemoveSignatoryBlockData {
+                company_id: id.to_owned(),
+                block_hash: "TODO_COMPANY_BLOCK_HASH".to_string(),
+                block_id: 9999,
+                signatory: signatory_node_id,
+            },
+            &full_identity.key_pair,
+            &full_identity.identity.public_key_pem,
+            timestamp,
+        )?;
+        self.identity_blockchain_store.add_block(&new_block).await?;
 
         Ok(())
     }
@@ -448,28 +529,36 @@ pub struct CompanyKeys {
 mod test {
     use super::*;
     use crate::{
+        blockchain::{identity::IdentityBlockchain, Blockchain},
         persistence::{
             self, company::MockCompanyStoreApi, contact::MockContactStoreApi,
             file_upload::MockFileUploadStoreApi, identity::MockIdentityStoreApi,
+            identity_chain::MockIdentityChainStoreApi,
         },
-        service::{contact_service::IdentityPublicData, identity_service::Identity},
+        service::{
+            contact_service::IdentityPublicData,
+            identity_service::{Identity, IdentityWithAll},
+        },
         tests::test::{TEST_PRIVATE_KEY, TEST_PUB_KEY},
     };
     use libp2p::PeerId;
     use mockall::predicate::{always, eq};
     use std::collections::HashMap;
+    use util::BcrKeys;
 
     fn get_service(
         mock_storage: MockCompanyStoreApi,
         mock_file_upload_storage: MockFileUploadStoreApi,
         mock_identity_storage: MockIdentityStoreApi,
         mock_contacts_storage: MockContactStoreApi,
+        mock_identity_chain_storage: MockIdentityChainStoreApi,
     ) -> CompanyService {
         CompanyService::new(
             Arc::new(mock_storage),
             Arc::new(mock_file_upload_storage),
             Arc::new(mock_identity_storage),
             Arc::new(mock_contacts_storage),
+            Arc::new(mock_identity_chain_storage),
         )
     }
 
@@ -478,12 +567,14 @@ mod test {
         MockFileUploadStoreApi,
         MockIdentityStoreApi,
         MockContactStoreApi,
+        MockIdentityChainStoreApi,
     ) {
         (
             MockCompanyStoreApi::new(),
             MockFileUploadStoreApi::new(),
             MockIdentityStoreApi::new(),
             MockContactStoreApi::new(),
+            MockIdentityChainStoreApi::new(),
         )
     }
 
@@ -513,14 +604,21 @@ mod test {
 
     #[tokio::test]
     async fn get_list_of_companies_baseline() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (mut storage, file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         storage.expect_get_all().returning(|| {
             let mut map = HashMap::new();
             let company_data = get_baseline_company_data();
             map.insert(company_data.0, company_data.1);
             Ok(map)
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
 
         let res = service.get_list_of_companies().await;
         assert!(res.is_ok());
@@ -534,21 +632,29 @@ mod test {
 
     #[tokio::test]
     async fn get_list_of_companies_propagates_persistence_errors() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (mut storage, file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         storage.expect_get_all().returning(|| {
             Err(persistence::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "test error",
             )))
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service.get_list_of_companies().await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn get_company_by_id_baseline() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (mut storage, file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         storage.expect_exists().returning(|_| true);
         storage
             .expect_get()
@@ -556,7 +662,13 @@ mod test {
         storage
             .expect_get_key_pair()
             .returning(|_| Ok(get_baseline_company_data().1 .1));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
 
         let res = service.get_company_by_id("some_id").await;
         assert!(res.is_ok());
@@ -566,16 +678,24 @@ mod test {
 
     #[tokio::test]
     async fn get_company_by_id_fails_if_company_doesnt_exist() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (mut storage, file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         storage.expect_exists().returning(|_| false);
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service.get_company_by_id("some_id").await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn get_company_by_id_propagates_persistence_errors() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (mut storage, file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         storage.expect_exists().returning(|_| true);
         storage.expect_get().returning(|_| {
             Err(persistence::Error::Io(std::io::Error::new(
@@ -583,28 +703,40 @@ mod test {
                 "test error",
             )))
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service.get_company_by_id("some_id").await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn create_company_baseline() {
-        let (mut storage, mut file_upload_store, mut identity_store, contact_store) =
-            get_storages();
+        let (
+            mut storage,
+            mut file_upload_store,
+            mut identity_store,
+            contact_store,
+            mut identity_chain_store,
+        ) = get_storages();
         file_upload_store
             .expect_save_attached_file()
             .returning(|_, _, _| Ok(()));
         storage.expect_save_key_pair().returning(|_, _| Ok(()));
         storage.expect_insert().returning(|_, _| Ok(()));
-        identity_store.expect_get().returning(|| {
+        identity_store.expect_get_full().returning(|| {
             let mut identity = Identity::new_empty();
             identity.public_key_pem = TEST_PUB_KEY.to_string();
-            Ok(identity)
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
         });
-        identity_store
-            .expect_get_node_id()
-            .returning(|| Ok(PeerId::random()));
         file_upload_store
             .expect_read_temp_upload_files()
             .returning(|_| {
@@ -616,7 +748,33 @@ mod test {
         file_upload_store
             .expect_remove_temp_upload_folder()
             .returning(|_| Ok(()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_chain_store
+            .expect_get_latest_block()
+            .returning(|| {
+                let mut identity = Identity::new_empty();
+                identity.public_key_pem = TEST_PUB_KEY.to_string();
+                Ok(IdentityBlockchain::new(
+                    &identity.into(),
+                    &PeerId::random().to_string(),
+                    &BcrKeys::new(),
+                    TEST_PUB_KEY,
+                    1731593928,
+                )
+                .unwrap()
+                .get_latest_block()
+                .clone())
+            });
+        identity_chain_store
+            .expect_add_block()
+            .returning(|_| Ok(()));
+
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
 
         let res = service
             .create_company(
@@ -629,6 +787,7 @@ mod test {
                 "2012-01-01".to_string(),
                 Some("some_file_id".to_string()),
                 Some("some_other_file_id".to_string()),
+                1731593928,
             )
             .await;
         assert!(res.is_ok());
@@ -652,7 +811,13 @@ mod test {
 
     #[tokio::test]
     async fn create_company_propagates_persistence_errors() {
-        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_save_key_pair().returning(|_, _| Ok(()));
         storage.expect_insert().returning(|_, _| {
             Err(persistence::Error::Io(std::io::Error::new(
@@ -660,15 +825,22 @@ mod test {
                 "test error",
             )))
         });
-        identity_store.expect_get().returning(|| {
+        identity_store.expect_get_full().returning(|| {
             let mut identity = Identity::new_empty();
             identity.public_key_pem = TEST_PUB_KEY.to_string();
-            Ok(identity)
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
         });
-        identity_store
-            .expect_get_node_id()
-            .returning(|| Ok(PeerId::random()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
             .create_company(
                 "name".to_string(),
@@ -680,6 +852,7 @@ mod test {
                 "2012-01-01".to_string(),
                 None,
                 None,
+                1731593928,
             )
             .await;
         assert!(res.is_err());
@@ -688,8 +861,13 @@ mod test {
     #[tokio::test]
     async fn edit_company_baseline() {
         let node_id = PeerId::random();
-        let (mut storage, mut file_upload_store, mut identity_store, contact_store) =
-            get_storages();
+        let (
+            mut storage,
+            mut file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_get().returning(move |_| {
             let mut data = get_baseline_company_data().1 .0;
             data.signatories = vec![node_id.to_string()];
@@ -719,7 +897,13 @@ mod test {
         file_upload_store
             .expect_remove_temp_upload_folder()
             .returning(|_| Ok(()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
             .edit_company(
                 "some_id",
@@ -734,9 +918,16 @@ mod test {
 
     #[tokio::test]
     async fn edit_company_fails_if_company_doesnt_exist() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (mut storage, file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         storage.expect_exists().returning(|_| false);
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
             .edit_company(
                 "some_id",
@@ -752,7 +943,13 @@ mod test {
     #[tokio::test]
     async fn edit_company_fails_if_caller_is_not_signatory() {
         let node_id = PeerId::random();
-        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| false);
         storage.expect_get().returning(|_| {
             let mut data = get_baseline_company_data().1 .0;
@@ -762,7 +959,13 @@ mod test {
         identity_store
             .expect_get_node_id()
             .returning(move || Ok(node_id));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
             .edit_company(
                 "some_id",
@@ -777,7 +980,13 @@ mod test {
 
     #[tokio::test]
     async fn edit_company_propagates_persistence_errors() {
-        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         let node_id = PeerId::random();
         storage.expect_get().returning(move |_| {
             let mut data = get_baseline_company_data().1 .0;
@@ -799,7 +1008,13 @@ mod test {
         identity_store
             .expect_get_node_id()
             .returning(move || Ok(node_id));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
             .edit_company(
                 "some_id",
@@ -814,7 +1029,13 @@ mod test {
 
     #[tokio::test]
     async fn add_signatory_baseline() {
-        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            mut contact_store,
+            mut identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
         storage.expect_update().returning(|_, _| Ok(()));
         contact_store.expect_get_map().returning(|| {
@@ -827,42 +1048,133 @@ mod test {
         storage
             .expect_get()
             .returning(|_| Ok(get_baseline_company_data().1 .0));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
+        identity_chain_store
+            .expect_get_latest_block()
+            .returning(|| {
+                let mut identity = Identity::new_empty();
+                identity.public_key_pem = TEST_PUB_KEY.to_string();
+                Ok(IdentityBlockchain::new(
+                    &identity.into(),
+                    &PeerId::random().to_string(),
+                    &BcrKeys::new(),
+                    TEST_PUB_KEY,
+                    1731593928,
+                )
+                .unwrap()
+                .get_latest_block()
+                .clone())
+            });
+        identity_chain_store
+            .expect_add_block()
+            .returning(|_| Ok(()));
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .add_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_ok());
     }
 
     #[tokio::test]
     async fn add_signatory_fails_if_signatory_not_in_contacts() {
-        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            mut contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
         contact_store
             .expect_get_map()
             .returning(|| Ok(HashMap::new()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .add_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn add_signatory_fails_if_company_doesnt_exist() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| false);
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .add_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn add_signatory_fails_if_signatory_is_already_signatory() {
-        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            mut contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
         contact_store.expect_get_map().returning(|| {
             let mut map = HashMap::new();
             let mut identity = IdentityPublicData::new_empty();
@@ -875,17 +1187,38 @@ mod test {
             data.signatories.push("new_signatory_node_id".to_string());
             Ok(data)
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .add_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn add_signatory_propagates_persistence_errors() {
-        let (mut storage, file_upload_store, identity_store, mut contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            mut contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
         contact_store.expect_get_map().returning(|| {
             let mut map = HashMap::new();
             let mut identity = IdentityPublicData::new_empty();
@@ -902,16 +1235,28 @@ mod test {
         storage
             .expect_get()
             .returning(|_| Ok(get_baseline_company_data().1 .0));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .add_signatory("some_id", "new_signatory_node_id".to_string())
+            .add_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn remove_signatory_baseline() {
-        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            mut identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
         storage.expect_get().returning(|_| {
             let mut data = get_baseline_company_data().1 .0;
@@ -920,24 +1265,76 @@ mod test {
                 .push("some_other_dude_or_dudette".to_string());
             Ok(data)
         });
-        identity_store
-            .expect_get_node_id()
-            .returning(|| Ok(PeerId::random()));
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
         storage.expect_update().returning(|_, _| Ok(()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_chain_store
+            .expect_get_latest_block()
+            .returning(|| {
+                let mut identity = Identity::new_empty();
+                identity.public_key_pem = TEST_PUB_KEY.to_string();
+                Ok(IdentityBlockchain::new(
+                    &identity.into(),
+                    &PeerId::random().to_string(),
+                    &BcrKeys::new(),
+                    TEST_PUB_KEY,
+                    1731593928,
+                )
+                .unwrap()
+                .get_latest_block()
+                .clone())
+            });
+        identity_chain_store
+            .expect_add_block()
+            .returning(|_| Ok(()));
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .remove_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_ok());
     }
 
     #[tokio::test]
     async fn remove_signatory_fails_if_company_doesnt_exist() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| false);
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .remove_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
@@ -945,8 +1342,13 @@ mod test {
     #[tokio::test]
     async fn remove_signatory_removing_self_removes_company() {
         let node_id = PeerId::random();
-        let (mut storage, mut file_upload_store, mut identity_store, contact_store) =
-            get_storages();
+        let (
+            mut storage,
+            mut file_upload_store,
+            mut identity_store,
+            contact_store,
+            mut identity_chain_store,
+        ) = get_storages();
         file_upload_store
             .expect_delete_attached_files()
             .returning(|_| Ok(()));
@@ -957,21 +1359,58 @@ mod test {
             data.signatories.push(node_id.to_string());
             Ok(data)
         });
-        identity_store
-            .expect_get_node_id()
-            .returning(move || Ok(node_id));
+        identity_store.expect_get_full().returning(move || {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: node_id,
+            })
+        });
         storage.expect_update().returning(|_, _| Ok(()));
         storage.expect_remove().returning(|_| Ok(()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_chain_store
+            .expect_get_latest_block()
+            .returning(|| {
+                let mut identity = Identity::new_empty();
+                identity.public_key_pem = TEST_PUB_KEY.to_string();
+                Ok(IdentityBlockchain::new(
+                    &identity.into(),
+                    &PeerId::random().to_string(),
+                    &BcrKeys::new(),
+                    TEST_PUB_KEY,
+                    1731593928,
+                )
+                .unwrap()
+                .get_latest_block()
+                .clone())
+            });
+        identity_chain_store
+            .expect_add_block()
+            .returning(|_| Ok(()));
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .remove_signatory("some_id", node_id.to_string())
+            .remove_signatory("some_id", node_id.to_string(), 1731593928)
             .await;
         assert!(res.is_ok());
     }
 
     #[tokio::test]
     async fn remove_signatory_fails_if_signatory_is_not_in_company() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
         storage.expect_get().returning(|_| {
             let mut data = get_baseline_company_data().1 .0;
@@ -980,32 +1419,74 @@ mod test {
             data.signatories.push("the_founder".to_string());
             Ok(data)
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .remove_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn remove_signatory_fails_on_last_signatory() {
-        let (mut storage, file_upload_store, identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
         storage.expect_get().returning(|_| {
             let mut data = get_baseline_company_data().1 .0;
             data.signatories.push("the_founder".to_string());
             Ok(data)
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .remove_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
 
     #[tokio::test]
     async fn remove_signatory_propagates_persistence_errors() {
-        let (mut storage, file_upload_store, mut identity_store, contact_store) = get_storages();
+        let (
+            mut storage,
+            file_upload_store,
+            mut identity_store,
+            contact_store,
+            identity_chain_store,
+        ) = get_storages();
         storage.expect_exists().returning(|_| true);
         storage.expect_get().returning(|_| {
             let mut data = get_baseline_company_data().1 .0;
@@ -1014,18 +1495,30 @@ mod test {
                 .push("some_other_dude_or_dudette".to_string());
             Ok(data)
         });
-        identity_store
-            .expect_get_node_id()
-            .returning(|| Ok(PeerId::random()));
+        identity_store.expect_get_full().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityWithAll {
+                identity,
+                key_pair: BcrKeys::new(),
+                peer_id: PeerId::random(),
+            })
+        });
         storage.expect_update().returning(|_, _| {
             Err(persistence::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "test error",
             )))
         });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
         let res = service
-            .remove_signatory("some_id", "new_signatory_node_id".to_string())
+            .remove_signatory("some_id", "new_signatory_node_id".to_string(), 1731593928)
             .await;
         assert!(res.is_err());
     }
@@ -1038,7 +1531,8 @@ mod test {
         let expected_encrypted =
             util::rsa::encrypt_bytes_with_public_key(&file_bytes, TEST_PUB_KEY).unwrap();
 
-        let (storage, mut file_upload_store, identity_store, contact_store) = get_storages();
+        let (storage, mut file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         file_upload_store
             .expect_save_attached_file()
             .with(always(), eq(company_id), eq(file_name))
@@ -1050,7 +1544,13 @@ mod test {
             .with(eq(company_id), eq(file_name))
             .times(1)
             .returning(move |_, _| Ok(expected_encrypted.clone()));
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
 
         let file = service
             .encrypt_and_save_uploaded_file(file_name, &file_bytes, company_id, TEST_PUB_KEY)
@@ -1058,7 +1558,7 @@ mod test {
             .unwrap();
         assert_eq!(
             file.hash,
-            String::from("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9")
+            String::from("DULfJyE3WQqNxy3ymuhAChyNR3yufT88pmqvAazKFMG4")
         );
         assert_eq!(file.name, String::from(file_name));
 
@@ -1071,7 +1571,8 @@ mod test {
 
     #[tokio::test]
     async fn save_encrypt_propagates_write_file_error() {
-        let (storage, mut file_upload_store, identity_store, contact_store) = get_storages();
+        let (storage, mut file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         file_upload_store
             .expect_save_attached_file()
             .returning(|_, _, _| {
@@ -1080,7 +1581,13 @@ mod test {
                     "test error",
                 )))
             });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
 
         assert!(service
             .encrypt_and_save_uploaded_file("file_name", &[], "test", TEST_PUB_KEY)
@@ -1090,7 +1597,8 @@ mod test {
 
     #[tokio::test]
     async fn open_decrypt_propagates_read_file_error() {
-        let (storage, mut file_upload_store, identity_store, contact_store) = get_storages();
+        let (storage, mut file_upload_store, identity_store, contact_store, identity_chain_store) =
+            get_storages();
         file_upload_store
             .expect_open_attached_file()
             .returning(|_, _| {
@@ -1099,7 +1607,13 @@ mod test {
                     "test error",
                 )))
             });
-        let service = get_service(storage, file_upload_store, identity_store, contact_store);
+        let service = get_service(
+            storage,
+            file_upload_store,
+            identity_store,
+            contact_store,
+            identity_chain_store,
+        );
 
         assert!(service
             .open_and_decrypt_file("test", "test", TEST_PRIVATE_KEY)

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -56,7 +56,6 @@ pub trait CompanyServiceApi: Send + Sync {
         &self,
         id: &str,
         signatory_node_id: String,
-
         timestamp: i64,
     ) -> Result<()>;
 
@@ -65,7 +64,6 @@ pub trait CompanyServiceApi: Send + Sync {
         &self,
         id: &str,
         signatory_node_id: String,
-
         timestamp: i64,
     ) -> Result<()>;
 

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -6,7 +6,7 @@ use crate::{
     util::{self, BcrKeys},
 };
 
-use crate::blockchain::identity::IdentityBlockchain;
+use crate::blockchain::identity::{IdentityBlock, IdentityBlockchain, IdentityUpdateBlockData};
 use crate::blockchain::Blockchain;
 use crate::persistence::identity_chain::IdentityChainStoreApi;
 use async_trait::async_trait;
@@ -18,7 +18,14 @@ use std::sync::Arc;
 #[async_trait]
 pub trait IdentityServiceApi: Send + Sync {
     /// Updates the identity
-    async fn update_identity(&self, identity: &Identity) -> Result<()>;
+    async fn update_identity(
+        &self,
+        name: Option<String>,
+        company: Option<String>,
+        email: Option<String>,
+        postal_address: Option<String>,
+        timestamp: i64,
+    ) -> Result<()>;
     /// Gets the full local identity, including the key pair and peer id
     async fn get_full_identity(&self) -> Result<IdentityWithAll>;
     /// Gets the local identity
@@ -71,8 +78,50 @@ impl IdentityServiceApi for IdentityService {
         Ok(identity)
     }
 
-    async fn update_identity(&self, identity: &Identity) -> Result<()> {
-        self.store.save(identity).await?;
+    async fn update_identity(
+        &self,
+        name: Option<String>,
+        company: Option<String>,
+        email: Option<String>,
+        postal_address: Option<String>,
+        timestamp: i64,
+    ) -> Result<()> {
+        let mut identity = self.store.get().await?;
+
+        if let Some(ref name_to_set) = name {
+            identity.name = name_to_set.trim().to_owned();
+        }
+
+        if let Some(ref company_to_set) = company {
+            identity.company = company_to_set.trim().to_owned();
+        }
+
+        if let Some(ref email_to_set) = email {
+            identity.email = email_to_set.trim().to_owned();
+        }
+
+        if let Some(ref postal_address_to_set) = postal_address {
+            identity.postal_address = postal_address_to_set.trim().to_owned();
+        }
+
+        let keys = self.store.get_key_pair().await?;
+
+        let previous_block = self.blockchain_store.get_latest_block().await?;
+        let new_block = IdentityBlock::create_block_for_update(
+            &previous_block,
+            &IdentityUpdateBlockData {
+                name,
+                company,
+                email,
+                postal_address,
+            },
+            &keys,
+            &identity.public_key_pem,
+            timestamp,
+        )?;
+        self.blockchain_store.add_block(&new_block).await?;
+
+        self.store.save(&identity).await?;
         self.client
             .clone()
             .put_identity_public_data_in_dht()
@@ -108,6 +157,7 @@ impl IdentityServiceApi for IdentityService {
         let (private_key_pem, public_key_pem) = util::rsa::create_rsa_key_pair()?;
 
         let keys = self.store.get_key_pair().await?;
+        let node_id = self.store.get_node_id().await?.to_string();
 
         let s = bitcoin::secp256k1::Secp256k1::new();
 
@@ -135,8 +185,15 @@ impl IdentityServiceApi for IdentityService {
             nostr_relay: None,
         };
 
+        let rsa_pub_key = identity.public_key_pem.clone();
         // create new identity chain and persist it
-        let identity_chain = IdentityBlockchain::new(&identity, &keys, timestamp)?;
+        let identity_chain = IdentityBlockchain::new(
+            &identity.clone().into(),
+            &node_id,
+            &keys,
+            &rsa_pub_key,
+            timestamp,
+        )?;
         let first_block = identity_chain.get_first_block();
         self.blockchain_store.add_block(first_block).await?;
 
@@ -160,7 +217,6 @@ pub struct IdentityWithAll {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(crate = "rocket::serde")]
 pub struct Identity {
     pub name: String,
     pub company: String,
@@ -175,14 +231,6 @@ pub struct Identity {
     pub bitcoin_private_key: String,
     pub nostr_npub: Option<String>,
     pub nostr_relay: Option<String>,
-}
-
-macro_rules! update_field {
-    ($self:expr, $other:expr, $field:ident) => {
-        if !$other.$field.is_empty() {
-            $self.$field = $other.$field.clone();
-        }
-    };
 }
 
 impl Identity {
@@ -203,46 +251,18 @@ impl Identity {
             nostr_relay: None,
         }
     }
-
-    fn all_changeable_fields_empty(&self) -> bool {
-        self.name.is_empty()
-            && self.company.is_empty()
-            && self.postal_address.is_empty()
-            && self.email.is_empty()
-    }
-
-    fn all_changeable_fields_equal_to(&self, other: &Self) -> bool {
-        self.name == other.name
-            && self.company == other.company
-            && self.postal_address == other.postal_address
-            && self.email == other.email
-    }
-
-    pub fn update_valid(&self, other: &Self) -> bool {
-        if other.all_changeable_fields_empty() {
-            return false;
-        }
-        if self.all_changeable_fields_equal_to(other) {
-            return false;
-        }
-        true
-    }
-
-    pub fn update_from(&mut self, other: &Identity) {
-        update_field!(self, other, name);
-        update_field!(self, other, company);
-        update_field!(self, other, postal_address);
-        update_field!(self, other, email);
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::persistence::{
-        self, bill::MockBillStoreApi, company::MockCompanyStoreApi,
-        file_upload::MockFileUploadStoreApi, identity::MockIdentityStoreApi,
-        identity_chain::MockIdentityChainStoreApi,
+    use crate::{
+        persistence::{
+            self, bill::MockBillStoreApi, company::MockCompanyStoreApi,
+            file_upload::MockFileUploadStoreApi, identity::MockIdentityStoreApi,
+            identity_chain::MockIdentityChainStoreApi,
+        },
+        tests::test::TEST_PUB_KEY,
     };
     use futures::channel::mpsc;
 
@@ -283,22 +303,6 @@ mod test {
         )
     }
 
-    #[test]
-    fn test_update() {
-        let mut identity = Identity::new_empty();
-        let mut other_identity = Identity::new_empty();
-        assert!(identity.all_changeable_fields_empty());
-        assert!(identity.all_changeable_fields_equal_to(&other_identity));
-        assert!(!identity.update_valid(&other_identity));
-        other_identity.name = String::from("changed");
-        assert!(!identity.all_changeable_fields_equal_to(&other_identity));
-        assert!(!other_identity.all_changeable_fields_empty());
-        assert!(identity.update_valid(&other_identity));
-        identity.update_from(&other_identity);
-        assert_eq!(identity.name, String::from("changed"));
-        assert!(!identity.update_valid(&other_identity));
-    }
-
     #[tokio::test]
     async fn create_identity_baseline() {
         let mut storage = MockIdentityStoreApi::new();
@@ -306,6 +310,9 @@ mod test {
         storage
             .expect_get_key_pair()
             .returning(|| Ok(BcrKeys::new()));
+        storage
+            .expect_get_node_id()
+            .returning(move || Ok(PeerId::random()));
         let mut chain_storage = MockIdentityChainStoreApi::new();
         chain_storage.expect_add_block().returning(|_| Ok(()));
 
@@ -359,9 +366,35 @@ mod test {
     async fn update_identity_calls_storage() {
         let mut storage = MockIdentityStoreApi::new();
         storage.expect_save().returning(|_| Ok(()));
+        storage
+            .expect_get_key_pair()
+            .returning(|| Ok(BcrKeys::new()));
+        storage.expect_get().returning(move || {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(identity)
+        });
+        let mut chain_storage = MockIdentityChainStoreApi::new();
+        chain_storage.expect_get_latest_block().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityBlockchain::new(
+                &identity.into(),
+                &PeerId::random().to_string(),
+                &BcrKeys::new(),
+                TEST_PUB_KEY,
+                1731593928,
+            )
+            .unwrap()
+            .get_latest_block()
+            .clone())
+        });
+        chain_storage.expect_add_block().returning(|_| Ok(()));
 
-        let service = get_service(storage);
-        let res = service.update_identity(&Identity::new_empty()).await;
+        let service = get_service_with_chain_storage(storage, chain_storage);
+        let res = service
+            .update_identity(Some("new_name".to_string()), None, None, None, 1731593928)
+            .await;
 
         assert!(res.is_ok());
     }
@@ -369,15 +402,41 @@ mod test {
     #[tokio::test]
     async fn update_identity_propagates_errors() {
         let mut storage = MockIdentityStoreApi::new();
+        storage
+            .expect_get_key_pair()
+            .returning(|| Ok(BcrKeys::new()));
+        storage.expect_get().returning(move || {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(identity)
+        });
         storage.expect_save().returning(|_| {
             Err(persistence::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "test error",
             )))
         });
+        let mut chain_storage = MockIdentityChainStoreApi::new();
+        chain_storage.expect_get_latest_block().returning(|| {
+            let mut identity = Identity::new_empty();
+            identity.public_key_pem = TEST_PUB_KEY.to_string();
+            Ok(IdentityBlockchain::new(
+                &identity.into(),
+                &PeerId::random().to_string(),
+                &BcrKeys::new(),
+                TEST_PUB_KEY,
+                1731593928,
+            )
+            .unwrap()
+            .get_latest_block()
+            .clone())
+        });
+        chain_storage.expect_add_block().returning(|_| Ok(()));
 
-        let service = get_service(storage);
-        let res = service.update_identity(&Identity::new_empty()).await;
+        let service = get_service_with_chain_storage(storage, chain_storage);
+        let res = service
+            .update_identity(Some("new_name".to_string()), None, None, None, 1731593928)
+            .await;
 
         assert!(res.is_err());
     }

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -195,6 +195,7 @@ pub async fn create_service_context(
         db.identity_store.clone(),
         db.file_upload_store.clone(),
         bitcoin_client,
+        db.identity_chain_store.clone(),
     );
     let identity_service = IdentityService::new(
         client.clone(),
@@ -207,6 +208,7 @@ pub async fn create_service_context(
         db.file_upload_store.clone(),
         db.identity_store,
         db.contact_store,
+        db.identity_chain_store,
     );
     let file_upload_service = FileUploadService::new(db.file_upload_store);
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,9 +4,12 @@ pub mod file;
 pub mod numbers_to_words;
 pub mod rsa;
 pub mod terminal;
-use bitcoin::{Network, PrivateKey, PublicKey};
+
 pub use crypto::BcrKeys;
+
+use bitcoin::{Network, PrivateKey, PublicKey};
 use openssl::sha::sha256;
+use thiserror::Error;
 use uuid::Uuid;
 
 #[cfg(not(test))]
@@ -26,5 +29,22 @@ pub fn create_bitcoin_keypair(used_network: Network) -> (PrivateKey, PublicKey) 
 }
 
 pub fn sha256_hash(bytes: &[u8]) -> String {
-    hex::encode(sha256(bytes))
+    base58_encode(&sha256(bytes))
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Errors stemming base58 decoding
+    #[error("Decode base58 error: {0}")]
+    Base58(#[from] bs58::decode::Error),
+}
+
+pub fn base58_encode(bytes: &[u8]) -> String {
+    bs58::encode(bytes).into_string()
+}
+
+#[allow(dead_code)]
+pub fn base58_decode(input: &str) -> std::result::Result<Vec<u8>, Error> {
+    let result = bs58::decode(input).into_vec()?;
+    Ok(result)
 }

--- a/src/util/rsa.rs
+++ b/src/util/rsa.rs
@@ -27,7 +27,6 @@ pub fn create_rsa_key_pair() -> Result<(String, String)> {
     ))
 }
 
-//-------------------------Bytes common-------------------------
 pub fn encrypt_bytes_with_public_key(bytes: &[u8], public_key: &str) -> Result<Vec<u8>> {
     let public_key = Rsa::public_key_from_pem(public_key.as_bytes())?;
 

--- a/src/web/data.rs
+++ b/src/web/data.rs
@@ -87,10 +87,10 @@ pub struct AcceptBitcreditBillPayload {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 pub struct ChangeIdentityPayload {
-    pub name: String,
-    pub company: String,
-    pub email: String,
-    pub postal_address: String,
+    pub name: Option<String>,
+    pub company: Option<String>,
+    pub email: Option<String>,
+    pub postal_address: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/web/handlers/company/mod.rs
+++ b/src/web/handlers/company/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     dht::{GossipsubEvent, GossipsubEventId},
+    external,
     service::{
         self,
         company_service::{CompanyPublicData, CompanyToReturn},
@@ -96,6 +97,7 @@ pub async fn create(
     create_company_payload: Json<CreateCompanyPayload>,
 ) -> Result<Json<CompanyToReturn>> {
     let payload = create_company_payload.0;
+    let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
     let created_company = state
         .company_service
         .create_company(
@@ -108,6 +110,7 @@ pub async fn create(
             payload.registration_date,
             payload.proof_of_registration_file_upload_id,
             payload.logo_file_upload_id,
+            timestamp,
         )
         .await?;
 
@@ -159,9 +162,10 @@ pub async fn add_signatory(
     add_signatory_payload: Json<AddSignatoryPayload>,
 ) -> Result<()> {
     let payload = add_signatory_payload.0;
+    let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
     state
         .company_service
-        .add_signatory(&payload.id, payload.signatory_node_id.clone())
+        .add_signatory(&payload.id, payload.signatory_node_id.clone(), timestamp)
         .await?;
 
     let mut dht_client = state.dht_client();
@@ -193,9 +197,10 @@ pub async fn remove_signatory(
     remove_signatory_payload: Json<RemoveSignatoryPayload>,
 ) -> Result<()> {
     let payload = remove_signatory_payload.0;
+    let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
     state
         .company_service
-        .remove_signatory(&payload.id, payload.signatory_node_id.clone())
+        .remove_signatory(&payload.id, payload.signatory_node_id.clone(), timestamp)
         .await?;
 
     let mut dht_client = state.dht_client();


### PR DESCRIPTION
## 📝 Description

Future PRs in this task: adding atomicity for surrealdb blockchain actions and rollback logic in case of errors

This PR refactors the identity chain to use in-module data objects and a fail-safe API to add blocks.
It also switches from hex to base58 encoding and to borsh for the signature.
It also re-implements changing identity fields to use an Option-based approach.

Relates to #140 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Added actions for identity chain

- **Refactoring:**
  - Identity chain API

- **Other Changes:**
  - Changed hex to base58

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

* Run tests
* Create a company, add/remove signatories, Create a new identity and do signed bill actions and make sure the according Identity Chain entries are added to surrealdb

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #140


---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
