### PR TITLE
add identity switch, use identity switch to issue bill as company

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-too-many-arguments-threshold=13
+too-many-arguments-threshold=14

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -215,7 +215,7 @@ pub trait Blockchain {
         self.blocks()
             .iter()
             .filter(|block| block.op_code() == &op_code)
-            .last()
+            .next_back()
             .unwrap_or_else(|| self.get_first_block())
     }
 

--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -230,7 +230,7 @@ impl Client {
                 .await?;
         }
 
-        self.company_store.insert(company_id, &company).await?;
+        self.company_store.insert(&company).await?;
         self.company_store
             .save_key_pair(company_id, &company_keys)
             .await?;
@@ -659,8 +659,8 @@ impl Client {
     }
 
     /// Checks the bill record for the local node, adding missing bills and starts providing them, if necessary
-    pub async fn update_bills_table(&mut self, node_id: String) -> Result<()> {
-        let node_request = self.node_request_for_bills(&node_id);
+    pub async fn update_bills_table(&mut self, node_id: &str) -> Result<()> {
+        let node_request = self.node_request_for_bills(node_id);
 
         let bill_ids = self.bill_store.get_bill_ids().await?;
         match self.get_record(node_request.clone()).await {
@@ -1606,6 +1606,7 @@ mod test {
             id.to_string(),
             (
                 Company {
+                    id: id.to_string(),
                     name: "some_name".to_string(),
                     country_of_registration: "AT".to_string(),
                     city_of_registration: "Vienna".to_string(),
@@ -3064,7 +3065,7 @@ mod test {
         company_store
             .expect_exists()
             .returning(|id| id == "company_1");
-        company_store.expect_insert().returning(|_, _| Ok(()));
+        company_store.expect_insert().returning(|_| Ok(()));
         company_store
             .expect_save_key_pair()
             .returning(|_, _| Ok(()));

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -21,7 +21,7 @@ pub trait CompanyStoreApi: Send + Sync {
     async fn get_all(&self) -> Result<HashMap<String, (Company, CompanyKeys)>>;
 
     /// Inserts the company with the given id
-    async fn insert(&self, id: &str, data: &Company) -> Result<()>;
+    async fn insert(&self, data: &Company) -> Result<()>;
 
     /// Updates the company with the given id
     async fn update(&self, id: &str, data: &Company) -> Result<()>;

--- a/src/service/contact_service.rs
+++ b/src/service/contact_service.rs
@@ -15,7 +15,7 @@ use crate::{
     CONFIG,
 };
 
-use super::Result;
+use super::{company_service::Company, Result};
 use log::info;
 
 #[cfg_attr(test, automock)]
@@ -345,6 +345,19 @@ impl From<Contact> for IdentityPublicData {
             postal_address: value.postal_address,
             email: value.email,
             nostr_relay: value.nostr_relays.first().cloned(),
+        }
+    }
+}
+
+impl From<Company> for IdentityPublicData {
+    fn from(value: Company) -> Self {
+        Self {
+            t: ContactType::Company,
+            node_id: value.id.clone(),
+            name: value.name,
+            postal_address: value.postal_address,
+            email: value.email,
+            nostr_relay: None,
         }
     }
 }

--- a/src/service/identity_service.rs
+++ b/src/service/identity_service.rs
@@ -167,7 +167,6 @@ impl IdentityServiceApi for IdentityService {
 #[derive(Clone, Debug)]
 pub struct IdentityWithAll {
     pub identity: Identity,
-    #[allow(dead_code)]
     pub key_pair: BcrKeys,
 }
 

--- a/src/web/data.rs
+++ b/src/web/data.rs
@@ -67,6 +67,11 @@ pub struct RequestToAcceptBitcreditBillPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct SwitchIdentity {
+    pub node_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct RequestToPayBitcreditBillPayload {
     pub bill_id: String,
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -61,7 +61,9 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             routes![
                 handlers::identity::create_identity,
                 handlers::identity::change_identity,
-                handlers::identity::return_identity
+                handlers::identity::return_identity,
+                handlers::identity::active,
+                handlers::identity::switch
             ],
         )
         .mount("/bitcredit", FileServer::from("frontend_build"))


### PR DESCRIPTION
## 📝 Description

* Adds the identity switch API (defaults to personal node_id on startup)
* Adds the possibility to issue bills as a company and as a person (rest of the bill signing logic will be implemented in #288
* A couple small refactorings, adding the company id to the company, improving the DB setup for companies and using a clippy lint from 1.86 (next_back instead of last)

Relates to #281 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above.

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. There are endpoints for switching identity and getting the active identity - try them out and make sure only the personal node_id and existing companies can be selected
2. Having a company selected, try to issue a bill and make sure the drawer is a company

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #282 

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
