### PR TITLE
chore(docker): add health check for surrealdb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       - "8001:8001"
       - "1909:1909"
     depends_on:
-      - surrealdb
+      surrealdb:
+        condition: service_healthy
+
   surrealdb:
     image: surrealdb/surrealdb:latest
     volumes:
@@ -25,3 +27,7 @@ services:
     user: ${UID}:${GID}
     ports:
       - "8800:8000"
+    healthcheck:
+      test: [ "CMD", "/surreal", "is-ready" ]
+      interval: 5s
+      retries: 5


### PR DESCRIPTION
Adds a health check for surrealdb and starts the backend only when the container is healthy.

This fixes connection errors at starup, i.e.:
```
bitcredit-1  | [ERROR bitcredit::persistence::db] Error connecting to SurrealDB with config: SurrealDbConfig { connection_string: "ws://surrealdb:8000", namespace: "default", database: "ebills" }. Error: There was an error processing a remote WS request: IO error: Connection refused (os error 111)
bitcredit-1  | Error: SurrealDB connection error There was an error processing a remote WS request: IO error: Connection refused (os error 111)
bitcredit-1  | 
bitcredit-1  | Caused by:
bitcredit-1  |     0: There was an error processing a remote WS request: IO error: Connection refused (os error 111)
bitcredit-1  |     1: There was an error processing a remote WS request: IO error: Connection refused (os error 111)
bitcredit-1  | 
bitcredit-1  | Stack backtrace:
bitcredit-1  |    0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
bitcredit-1  |    1: bitcredit::main::{{closure}}
bitcredit-1  |    2: tokio::runtime::park::CachedParkThread::block_on
bitcredit-1  |    3: tokio::runtime::context::runtime::enter_runtime
bitcredit-1  |    4: tokio::runtime::runtime::Runtime::block_on
bitcredit-1  |    5: bitcredit::main
bitcredit-1  |    6: std::sys::backtrace::__rust_begin_short_backtrace
bitcredit-1  |    7: std::rt::lang_start::{{closure}}
bitcredit-1  |    8: std::rt::lang_start_internal
bitcredit-1  |    9: main
bitcredit-1  |   10: <unknown>
bitcredit-1  |   11: __libc_start_main
bitcredit-1  |   12: _start
```

Test with `docker compose up` and verify the status of `surrealdb` is "Up (healthy)".