### PR TITLE
chore(config): ability to specify mint url

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,8 @@ The following options are available:
 * `HTTP_PORT` / `--http-port` - the HTTP address (default: 8000)
 * `HTTP_ADDRESS` / `--http-address` - the HTTP address (default: 127.0.0.1)
 * `RUST_LOG` - the log level, e.g.: info, trace, debug, error (default: error)
+* `NOSTR_RELAY` - nostr relay endpoint (default: ws://localhost:8080)
+* `MINT_URL` - cashu mint endpoint (default: http://127.0.0.1:3338)
 
 ## Example
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,8 @@ pub struct Config {
     pub environment: String,
     #[arg(default_value_t = String::from("ws://localhost:8080"), long, env = "NOSTR_RELAY")]
     pub nostr_relay: String,
+    #[arg(default_value_t = String::from("http://127.0.0.1:3338"), long, env = "MINT_URL")]
+    pub mint_url: String,
 }
 
 impl Config {

--- a/src/external/mint.rs
+++ b/src/external/mint.rs
@@ -1,4 +1,5 @@
 use crate::constants::QUOTE_MAP_FILE_PATH;
+use crate::CONFIG;
 use crate::service::bill_service::BillKeys as LocalBillKeys;
 use crate::service::bill_service::BitcreditEbillQuote;
 use crate::web::data::RequestToMintBitcreditBillPayload;
@@ -30,7 +31,7 @@ pub async fn accept_mint_bitcredit(
         .await
         .expect("Cannot parse local store");
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse(CONFIG.mint_url.as_str()).expect("Invalid url");
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
@@ -53,7 +54,7 @@ pub async fn check_bitcredit_quote(bill_id: &str, node_id: &str) {
         .await
         .expect("Cannot parse local store");
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse(CONFIG.mint_url.as_str()).expect("Invalid url");
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
@@ -85,7 +86,7 @@ pub async fn client_accept_bitcredit_quote(bill_id: &String) -> String {
         .await
         .expect("Cannot parse local store");
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse(CONFIG.mint_url.as_str()).expect("Invalid url");
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
@@ -141,7 +142,7 @@ pub async fn request_to_mint_bitcredit(
         .await
         .expect("Cannot parse local store");
 
-    let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    let mint_url = Url::parse(CONFIG.mint_url.as_str()).expect("Invalid url");
 
     let wallet: Wallet<_, CrossPlatformHttpClient> = Wallet::builder()
         .with_localstore(localstore)
@@ -189,7 +190,7 @@ pub async fn init_wallet() {
         .expect("Cannot parse local store");
 
     // //TODO: take from params
-    // let mint_url = Url::parse("http://127.0.0.1:3338").expect("Invalid url");
+    // let mint_url = Url::parse(CONFIG.mint_url.as_str()).expect("Invalid url");
     //
     // let identity: Identity = read_identity_from_file();
     // let bitcoin_key = identity.node_id.clone();


### PR DESCRIPTION
This PR add a `MINT_URL` config argument.
Before this commit, the mint has been hardcoded to `127.0.0.1:3338`.
After this commit is applied, one can configure the mint endpoint with env var `MINT_URL`.

This is especially needed when running backend and mint in a docker-compose setup.
