### PR TITLE
Hotfix datetime now returning UNIX 0

### DIFF
--- a/src/util/date.rs
+++ b/src/util/date.rs
@@ -6,7 +6,7 @@ pub type DateTimeUtc = DateTime<Utc>;
 /// Returns the current time as DateTime
 #[allow(dead_code)]
 pub fn now() -> DateTimeUtc {
-    DateTime::default()
+    Utc::now()
 }
 
 /// Quickly create a DateTimeUtc from a timestamp. chrone does not
@@ -34,8 +34,24 @@ pub fn date_time_string_to_i64_timestamp(
 
 #[cfg(test)]
 mod tests {
+    use std::time::UNIX_EPOCH;
+
     use super::*;
     use chrono::Utc;
+
+    #[test]
+    fn test_now() {
+        let now = now().timestamp();
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        assert!(
+            now >= timestamp - 1,
+            "now date was {} seconds smaller than expected",
+            (timestamp - now)
+        );
+    }
 
     #[test]
     fn test_date_time_string_to_u64_timestamp_with_default_format() {


### PR DESCRIPTION
## 📝 Description

Date utils `now()` was returning UNIX time at 0

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **Bug Fixes:**
  - Return correct date from `now()` function

---

## 💡 How to Test

1. cargo test
