### PR TITLE
250 bills to surrealdb

### DIFF
--- a/src/blockchain/bill/mod.rs
+++ b/src/blockchain/bill/mod.rs
@@ -72,7 +72,7 @@ pub struct BillBlockToReturn {
     pub data: String,
     pub previous_hash: String,
     pub signature: String,
-    pub operation_code: BillOpCode,
+    pub op_code: BillOpCode,
     pub label: String,
 }
 
@@ -89,7 +89,7 @@ impl BillBlockToReturn {
             data: block.data,
             previous_hash: block.previous_hash,
             signature: block.signature,
-            operation_code: block.operation_code,
+            op_code: block.op_code,
             label,
         })
     }
@@ -125,7 +125,7 @@ pub mod tests {
         let identity = get_baseline_identity();
 
         let result = BillBlockchain::new(
-            &BillIssueBlockData::from(bill, None),
+            &BillIssueBlockData::from(bill, None, 1731593928),
             identity.key_pair,
             None,
             BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP).unwrap(),

--- a/src/blockchain/company/mod.rs
+++ b/src/blockchain/company/mod.rs
@@ -8,7 +8,7 @@ use borsh::to_vec;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
-#[derive(BorshSerialize, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum CompanyOpCode {
     Create,
     Update,
@@ -26,7 +26,7 @@ pub struct CompanyBlockDataToHash {
     timestamp: u64,
     public_key: String,
     signatory_node_id: String,
-    operation_code: CompanyOpCode,
+    op_code: CompanyOpCode,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -45,7 +45,7 @@ pub struct CompanyBlockData {
     key: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct CompanyBlock {
     pub company_id: String,
     pub id: u64,
@@ -166,7 +166,7 @@ impl Block for CompanyBlock {
             timestamp: self.timestamp(),
             public_key: self.public_key().to_owned(),
             signatory_node_id: self.signatory_node_id.clone(),
-            operation_code: self.op_code().to_owned(),
+            op_code: self.op_code().to_owned(),
         };
         data
     }
@@ -200,7 +200,7 @@ impl CompanyBlock {
             timestamp,
             public_key: aggregated_public_key.clone(),
             signatory_node_id: signatory_node_id.clone(),
-            operation_code: op_code.clone(),
+            op_code: op_code.clone(),
         })?;
         let signature = crypto::aggregated_signature(&hash, &keys)?;
 
@@ -398,7 +398,7 @@ impl CompanyBlock {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
 pub struct CompanyBlockchain {
     blocks: Vec<CompanyBlock>,
 }

--- a/src/blockchain/identity/mod.rs
+++ b/src/blockchain/identity/mod.rs
@@ -24,7 +24,7 @@ pub struct IdentityBlockDataToHash {
     data: String,
     timestamp: u64,
     public_key: String,
-    operation_code: IdentityOpCode,
+    op_code: IdentityOpCode,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -144,7 +144,7 @@ impl Block for IdentityBlock {
             data: self.data().to_owned(),
             timestamp: self.timestamp(),
             public_key: self.public_key().to_owned(),
-            operation_code: self.op_code().to_owned(),
+            op_code: self.op_code().to_owned(),
         };
         data
     }
@@ -165,7 +165,7 @@ impl IdentityBlock {
             data: data.clone(),
             timestamp,
             public_key: keys.get_public_key(),
-            operation_code: op_code.clone(),
+            op_code: op_code.clone(),
         })?;
         let signature = crypto::signature(&hash, &keys.get_private_key_string())?;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,3 +45,4 @@ pub const DB_DATA: &str = "data";
 pub const DB_OP_CODE: &str = "op_code";
 
 pub const DB_COMPANY_ID: &str = "company_id";
+pub const DB_BILL_ID: &str = "bill_id";

--- a/src/dht/behaviour.rs
+++ b/src/dht/behaviour.rs
@@ -256,7 +256,7 @@ pub struct BillFileRequest {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BillKeysFileRequest {
     pub node_id: String,
-    pub key_name: String,
+    pub bill_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -322,7 +322,7 @@ pub fn parse_inbound_file_request(
         })),
         KEY_PREFIX => Ok(ParsedInboundFileRequest::BillKeys(BillKeysFileRequest {
             node_id,
-            key_name: parts[2].to_owned(),
+            bill_id: parts[2].to_owned(),
         })),
         BILL_ATTACHMENT_PREFIX => {
             if parts.len() < 4 {
@@ -562,7 +562,7 @@ mod tests {
             parse_inbound_file_request(&format!("{node_id}_KEY_TEST"), &peer_id).unwrap(),
             ParsedInboundFileRequest::BillKeys(BillKeysFileRequest {
                 node_id,
-                key_name: "TEST".to_string()
+                bill_id: "TEST".to_string()
             })
         );
     }
@@ -577,7 +577,7 @@ mod tests {
                 .unwrap(),
             ParsedInboundFileRequest::BillKeys(BillKeysFileRequest {
                 node_id,
-                key_name: "TEST".to_string()
+                bill_id: "TEST".to_string()
             })
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<()> {
     let dht = dht::dht_main(
         &conf,
         db.bill_store.clone(),
+        db.bill_blockchain_store.clone(),
         db.company_store.clone(),
         db.company_chain_store.clone(),
         db.identity_store.clone(),
@@ -88,7 +89,6 @@ async fn main() -> Result<()> {
             error!("Error while checking for new companies: {e}");
         }
         dht_client.put_companies_for_signatories().await?;
-        dht_client.put_companies_public_data_in_dht().await?;
         dht_client.start_providing_companies().await?;
         dht_client.subscribe_to_all_companies_topics().await?;
     }

--- a/src/persistence/bill.rs
+++ b/src/persistence/bill.rs
@@ -1,15 +1,11 @@
-use super::{file_storage_path, Result};
+use super::Result;
 use crate::{
-    blockchain::bill::BillBlockchain, service::bill_service::BillKeys,
-    util::file::is_not_hidden_or_directory_async,
+    blockchain::bill::{BillBlock, BillBlockchain},
+    service::bill_service::BillKeys,
 };
 use async_trait::async_trait;
-use std::path::PathBuf;
-use tokio::{
-    fs::{read, read_dir, write},
-    task,
-};
 
+use borsh::{from_slice, to_vec};
 #[cfg(test)]
 use mockall::automock;
 
@@ -17,157 +13,42 @@ use mockall::automock;
 #[async_trait]
 pub trait BillStoreApi: Send + Sync {
     /// Checks if the given bill exists
-    async fn bill_exists(&self, bill_id: &str) -> bool;
-
-    /// Reads the given bill as bytes
-    async fn get_bill_as_bytes(&self, bill_id: &str) -> Result<Vec<u8>>;
-
-    /// Reads the keys for the given bill as bytes
-    async fn get_bill_keys_as_bytes(&self, bill_id: &str) -> Result<Vec<u8>>;
-
+    async fn exists(&self, id: &str) -> bool;
     /// Gets all bill ids
-    async fn get_bill_ids(&self) -> Result<Vec<String>>;
-
-    /// Reads the blockchain of the given bill from disk
-    async fn read_bill_chain_from_file(&self, bill_id: &str) -> Result<BillBlockchain>;
-
-    /// Writes bill keys to file
-    async fn write_bill_keys_to_file(
-        &self,
-        bill_id: String,
-        private_key: String,
-        public_key: String,
-    ) -> Result<()>;
-
-    /// Writes the given pretty printed chain as JSON to a file
-    async fn write_blockchain_to_file(
-        &self,
-        bill_id: &str,
-        pretty_printed_chain_as_json: String,
-    ) -> Result<()>;
-
-    /// Reads bill keys from file
-    async fn read_bill_keys_from_file(&self, bill_id: &str) -> Result<BillKeys>;
+    async fn get_ids(&self) -> Result<Vec<String>>;
+    /// Saves the keys
+    async fn save_keys(&self, id: &str, keys: &BillKeys) -> Result<()>;
+    /// Get bill keys
+    async fn get_keys(&self, id: &str) -> Result<BillKeys>;
 }
 
-#[derive(Clone)]
-pub struct FileBasedBillStore {
-    folder: String,
-    keys_folder: String,
-}
-
-impl FileBasedBillStore {
-    pub async fn new(data_dir: &str, path: &str, keys_path: &str) -> Result<Self> {
-        let folder = file_storage_path(data_dir, path).await?;
-        let keys_folder = file_storage_path(data_dir, keys_path).await?;
-        Ok(Self {
-            folder,
-            keys_folder,
-        })
-    }
-
-    pub fn get_path_for_bills(&self) -> PathBuf {
-        PathBuf::from(self.folder.as_str())
-    }
-
-    pub fn get_path_for_bill(&self, bill_id: &str) -> PathBuf {
-        let mut path = PathBuf::from(self.folder.as_str()).join(bill_id);
-        path.set_extension("json");
-        path
-    }
-
-    pub fn get_path_for_bill_keys(&self, key_name: &str) -> PathBuf {
-        let mut path = PathBuf::from(self.keys_folder.as_str()).join(key_name);
-        path.set_extension("json");
-        path
-    }
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait BillChainStoreApi: Send + Sync {
+    /// Gets the latest block of the chain
+    async fn get_latest_block(&self, id: &str) -> Result<BillBlock>;
+    /// Adds the block to the chain
+    async fn add_block(&self, id: &str, block: &BillBlock) -> Result<()>;
+    /// Get the whole blockchain
+    async fn get_chain(&self, id: &str) -> Result<BillBlockchain>;
 }
 
 pub fn bill_chain_from_bytes(bytes: &[u8]) -> Result<BillBlockchain> {
-    let chain: BillBlockchain = serde_json::from_slice(bytes).map_err(super::Error::Json)?;
+    let chain: BillBlockchain = from_slice(bytes)?;
     Ok(chain)
 }
 
 pub fn bill_keys_from_bytes(bytes: &[u8]) -> Result<BillKeys> {
-    let keys: BillKeys = serde_json::from_slice(bytes).map_err(super::Error::Json)?;
+    let keys: BillKeys = from_slice(bytes)?;
     Ok(keys)
 }
 
-#[async_trait]
-impl BillStoreApi for FileBasedBillStore {
-    async fn bill_exists(&self, bill_id: &str) -> bool {
-        let bill_path = self.get_path_for_bill(bill_id).clone();
-        task::spawn_blocking(move || bill_path.exists())
-            .await
-            .unwrap_or(false)
-    }
+pub fn bill_keys_to_bytes(keys: &BillKeys) -> Result<Vec<u8>> {
+    let bytes = to_vec(&keys)?;
+    Ok(bytes)
+}
 
-    async fn get_bill_as_bytes(&self, bill_id: &str) -> Result<Vec<u8>> {
-        let bill_path = self.get_path_for_bill(bill_id);
-        let bytes = read(bill_path).await?;
-        Ok(bytes)
-    }
-
-    async fn get_bill_keys_as_bytes(&self, bill_id: &str) -> Result<Vec<u8>> {
-        let keys_path = self.get_path_for_bill_keys(bill_id);
-        let bytes = read(keys_path).await?;
-        Ok(bytes)
-    }
-
-    async fn get_bill_ids(&self) -> Result<Vec<String>> {
-        let mut res = vec![];
-        let mut dir = read_dir(self.get_path_for_bills()).await?;
-        while let Some(entry) = dir.next_entry().await? {
-            if is_not_hidden_or_directory_async(&entry).await {
-                if let Some(bill_id) = entry.path().file_stem() {
-                    if let Some(bill_id_str) = bill_id.to_str() {
-                        res.push(bill_id_str.to_owned());
-                    }
-                }
-            }
-        }
-        Ok(res)
-    }
-
-    async fn read_bill_chain_from_file(&self, bill_id: &str) -> Result<BillBlockchain> {
-        let path = self.get_path_for_bill(bill_id);
-        let bytes = read(path).await?;
-        serde_json::from_slice(&bytes).map_err(super::Error::Json)
-    }
-
-    async fn write_bill_keys_to_file(
-        &self,
-        bill_id: String,
-        private_key: String,
-        public_key: String,
-    ) -> Result<()> {
-        let keys: BillKeys = BillKeys {
-            private_key,
-            public_key,
-        };
-
-        let output_path = self.get_path_for_bill_keys(&bill_id);
-        write(
-            output_path,
-            serde_json::to_string_pretty(&keys).map_err(super::Error::Json)?,
-        )
-        .await?;
-        Ok(())
-    }
-
-    async fn write_blockchain_to_file(
-        &self,
-        bill_id: &str,
-        pretty_printed_chain_as_json: String,
-    ) -> Result<()> {
-        let path = self.get_path_for_bill(bill_id);
-        write(path, pretty_printed_chain_as_json).await?;
-        Ok(())
-    }
-
-    async fn read_bill_keys_from_file(&self, bill_id: &str) -> Result<BillKeys> {
-        let input_path = self.get_path_for_bill_keys(bill_id);
-        let bytes = read(&input_path).await?;
-        serde_json::from_slice(&bytes).map_err(super::Error::Json)
-    }
+pub fn bill_chain_to_bytes(chain: &BillBlockchain) -> Result<Vec<u8>> {
+    let bytes = to_vec(&chain)?;
+    Ok(bytes)
 }

--- a/src/persistence/company.rs
+++ b/src/persistence/company.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use super::Result;
 use async_trait::async_trait;
 
+use borsh::{from_slice, to_vec};
 #[cfg(test)]
 use mockall::automock;
 
@@ -50,31 +51,31 @@ pub trait CompanyChainStoreApi: Send + Sync {
 }
 
 pub fn company_from_bytes(bytes: &[u8]) -> Result<Company> {
-    let company: Company = serde_json::from_slice(bytes)?;
+    let company: Company = from_slice(bytes)?;
     Ok(company)
 }
 
 pub fn company_to_bytes(company: &Company) -> Result<Vec<u8>> {
-    let bytes = serde_json::to_vec(&company)?;
+    let bytes = to_vec(&company)?;
     Ok(bytes)
 }
 
 pub fn company_keys_from_bytes(bytes: &[u8]) -> Result<CompanyKeys> {
-    let company_keys: CompanyKeys = serde_json::from_slice(bytes)?;
+    let company_keys: CompanyKeys = from_slice(bytes)?;
     Ok(company_keys)
 }
 
 pub fn company_keys_to_bytes(company_keys: &CompanyKeys) -> Result<Vec<u8>> {
-    let bytes = serde_json::to_vec(&company_keys)?;
+    let bytes = to_vec(&company_keys)?;
     Ok(bytes)
 }
 
 pub fn company_chain_from_bytes(bytes: &[u8]) -> Result<CompanyBlockchain> {
-    let company_chain: CompanyBlockchain = serde_json::from_slice(bytes)?;
+    let company_chain: CompanyBlockchain = from_slice(bytes)?;
     Ok(company_chain)
 }
 
 pub fn company_chain_to_bytes(company_chain: &CompanyBlockchain) -> Result<Vec<u8>> {
-    let bytes = serde_json::to_vec(&company_chain)?;
+    let bytes = to_vec(&company_chain)?;
     Ok(bytes)
 }

--- a/src/persistence/db/bill.rs
+++ b/src/persistence/db/bill.rs
@@ -17,6 +17,7 @@ pub struct SurrealBillStore {
 impl SurrealBillStore {
     const CHAIN_TABLE: &'static str = "bill_chain";
     const KEYS_TABLE: &'static str = "bill_keys";
+    // These are in preparation for #330, improving the persistence performance for bills
     const DATA_TABLE: &'static str = "bill";
     const PARTICIPANTS_TABLE: &'static str = "bill_participants";
 

--- a/src/persistence/db/bill.rs
+++ b/src/persistence/db/bill.rs
@@ -1,0 +1,369 @@
+use super::Result;
+use crate::{
+    constants::{DB_BILL_ID, DB_TABLE},
+    persistence::{bill::BillStoreApi, Error},
+    service::bill_service::{Bill, BillKeys},
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use surrealdb::{engine::any::Any, sql::Thing, Surreal};
+
+#[derive(Clone)]
+pub struct SurrealBillStore {
+    db: Surreal<Any>,
+}
+
+impl SurrealBillStore {
+    const CHAIN_TABLE: &'static str = "bill_chain";
+    const KEYS_TABLE: &'static str = "bill_keys";
+    const DATA_TABLE: &'static str = "bill";
+    const PARTICIPANTS_TABLE: &'static str = "bill_participants";
+
+    pub fn new(db: Surreal<Any>) -> Self {
+        Self { db }
+    }
+
+    #[allow(dead_code)]
+    async fn get(&self, id: &str) -> Result<Bill> {
+        let result: Option<BillDb> = self.db.select((Self::DATA_TABLE, id)).await?;
+        match result {
+            None => Err(Error::NoSuchEntity("bill".to_string(), id.to_owned())),
+            Some(c) => Ok(c.into()),
+        }
+    }
+
+    #[allow(dead_code)]
+    async fn add_participants(&self, id: &str, node_ids: Vec<String>) -> Result<()> {
+        let participants = self.get_participants(id).await?;
+        let to_add: HashSet<String> = node_ids
+            .into_iter()
+            .filter(|n| !participants.iter().any(|p| p == n))
+            .collect();
+        let entities: Vec<BillParticipantDb> = to_add
+            .into_iter()
+            .map(|n| BillParticipantDb {
+                id: None,
+                bill_id: id.to_owned(),
+                node_id: n.clone(),
+            })
+            .collect();
+        let _: Option<BillParticipantDb> = self
+            .db
+            .create(Self::PARTICIPANTS_TABLE)
+            .content(entities)
+            .await?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    async fn get_participants(&self, id: &str) -> Result<Vec<String>> {
+        let result: Vec<BillParticipantDb> = self
+            .db
+            .query("SELECT * FROM type::table($table) WHERE bill_id = $bill_id")
+            .bind((DB_TABLE, Self::PARTICIPANTS_TABLE))
+            .bind((DB_BILL_ID, id.to_owned()))
+            .await?
+            .take(0)?;
+        let participants: HashSet<String> = result.into_iter().map(|bp| bp.node_id).collect();
+        Ok(participants.into_iter().collect())
+    }
+
+    #[allow(dead_code)]
+    async fn insert(&self, data: &Bill) -> Result<()> {
+        let id = data.id.to_owned();
+        let entity: BillDb = data.into();
+        let _: Option<BillDb> = self
+            .db
+            .create((Self::DATA_TABLE, id))
+            .content(entity)
+            .await?;
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    async fn update(&self, id: &str, data: &Bill) -> Result<()> {
+        let entity: BillDb = data.into();
+        let _: Option<BillDb> = self
+            .db
+            .update((Self::DATA_TABLE, id))
+            .content(entity)
+            .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BillStoreApi for SurrealBillStore {
+    async fn exists(&self, id: &str) -> bool {
+        match self
+            .db
+            .query(
+                "SELECT bill_id from type::table($table) WHERE bill_id = $bill_id GROUP BY bill_id",
+            )
+            .bind((DB_TABLE, Self::CHAIN_TABLE))
+            .bind((DB_BILL_ID, id.to_owned()))
+            .await
+        {
+            Ok(mut res) => {
+                res.take::<Option<BillIdDb>>(0)
+                    .map(|_| true)
+                    .unwrap_or(false)
+                    && self.get_keys(id).await.map(|_| true).unwrap_or(false)
+            }
+            Err(_) => false,
+        }
+    }
+
+    async fn get_ids(&self) -> Result<Vec<String>> {
+        let ids: Vec<BillIdDb> = self
+            .db
+            .query("SELECT bill_id from type::table($table) GROUP BY bill_id")
+            .bind((DB_TABLE, Self::CHAIN_TABLE))
+            .await?
+            .take(0)?;
+        Ok(ids.into_iter().map(|b| b.bill_id).collect())
+    }
+
+    async fn save_keys(&self, id: &str, key_pair: &BillKeys) -> Result<()> {
+        let entity: BillKeysDb = key_pair.into();
+        let _: Option<BillKeysDb> = self
+            .db
+            .create((Self::KEYS_TABLE, id))
+            .content(entity)
+            .await?;
+        Ok(())
+    }
+
+    async fn get_keys(&self, id: &str) -> Result<BillKeys> {
+        let result: Option<BillKeysDb> = self.db.select((Self::KEYS_TABLE, id)).await?;
+        match result {
+            None => Err(Error::NoSuchEntity("bill".to_string(), id.to_owned())),
+            Some(c) => Ok(c.into()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillIdDb {
+    pub bill_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillDb {
+    pub id: String,
+    pub drawer_node_id: String,
+    pub payer_node_id: String,
+    pub payee_node_id: String,
+    pub holder_node_id: String,
+    pub place_of_issuing: String,
+    pub issue_date: String,
+    pub maturity_date: String,
+    pub sum: u64,
+    pub currency_code: String,
+    pub place_of_payment: String,
+    pub requested_to_accept: bool,
+    pub accepted: bool,
+    pub requested_to_pay: bool,
+    pub paid: bool,
+    pub payment_address: Option<String>,
+    pub mint_token: Option<String>,
+    pub language: String,
+}
+
+impl From<BillDb> for Bill {
+    fn from(value: BillDb) -> Self {
+        Self {
+            id: value.id,
+            drawer_node_id: value.drawer_node_id,
+            payer_node_id: value.payer_node_id,
+            payee_node_id: value.payee_node_id,
+            holder_node_id: value.holder_node_id,
+            place_of_issuing: value.place_of_issuing,
+            issue_date: value.issue_date,
+            maturity_date: value.maturity_date,
+            sum: value.sum,
+            currency_code: value.currency_code,
+            place_of_payment: value.place_of_payment,
+            requested_to_accept: value.requested_to_accept,
+            accepted: value.accepted,
+            requested_to_pay: value.requested_to_pay,
+            paid: value.paid,
+            payment_address: value.payment_address,
+            mint_token: value.mint_token,
+            language: value.language,
+        }
+    }
+}
+
+impl From<&Bill> for BillDb {
+    fn from(value: &Bill) -> Self {
+        Self {
+            id: value.id.to_owned(),
+            drawer_node_id: value.drawer_node_id.clone(),
+            payer_node_id: value.payer_node_id.clone(),
+            payee_node_id: value.payee_node_id.clone(),
+            holder_node_id: value.holder_node_id.clone(),
+            place_of_issuing: value.place_of_issuing.clone(),
+            issue_date: value.issue_date.clone(),
+            maturity_date: value.maturity_date.clone(),
+            sum: value.sum,
+            currency_code: value.currency_code.clone(),
+            place_of_payment: value.place_of_payment.clone(),
+            requested_to_accept: value.requested_to_accept,
+            accepted: value.accepted,
+            requested_to_pay: value.requested_to_pay,
+            paid: value.paid,
+            payment_address: value.payment_address.clone(),
+            mint_token: value.mint_token.clone(),
+            language: value.language.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillKeysDb {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Thing>,
+    pub public_key: String,
+    pub private_key: String,
+}
+
+impl From<BillKeysDb> for BillKeys {
+    fn from(value: BillKeysDb) -> Self {
+        Self {
+            public_key: value.public_key,
+            private_key: value.private_key,
+        }
+    }
+}
+
+impl From<&BillKeys> for BillKeysDb {
+    fn from(value: &BillKeys) -> Self {
+        Self {
+            id: None,
+            public_key: value.public_key.clone(),
+            private_key: value.private_key.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillParticipantDb {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<Thing>,
+    pub bill_id: String,
+    pub node_id: String,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::SurrealBillStore;
+    use crate::{
+        blockchain::bill::{block::BillIssueBlockData, tests::get_baseline_identity, BillBlock},
+        persistence::{
+            bill::{BillChainStoreApi, BillStoreApi},
+            db::{bill_chain::SurrealBillChainStore, get_memory_db},
+        },
+        service::{
+            bill_service::{BillKeys, BitcreditBill},
+            contact_service::IdentityPublicData,
+        },
+        tests::tests::{get_bill_keys, TEST_PRIVATE_KEY_SECP, TEST_PUB_KEY_SECP},
+        util::BcrKeys,
+    };
+    use surrealdb::{engine::any::Any, Surreal};
+
+    async fn get_db() -> Surreal<Any> {
+        get_memory_db("test", "bill")
+            .await
+            .expect("could not create memory db")
+    }
+    async fn get_store(mem_db: Surreal<Any>) -> SurrealBillStore {
+        SurrealBillStore::new(mem_db)
+    }
+
+    async fn get_chain_store(mem_db: Surreal<Any>) -> SurrealBillChainStore {
+        SurrealBillChainStore::new(mem_db)
+    }
+
+    pub fn get_first_block(id: &str) -> BillBlock {
+        let mut bill = BitcreditBill::new_empty();
+        bill.id = id.to_owned();
+        bill.drawer = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
+        bill.payee = bill.drawer.clone();
+        bill.drawee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
+
+        BillBlock::create_block_for_issue(
+            id.to_owned(),
+            String::from("prevhash"),
+            &BillIssueBlockData::from(bill, None, 1731593928),
+            &get_baseline_identity().key_pair,
+            None,
+            &BcrKeys::from_private_key(&get_bill_keys().private_key).unwrap(),
+            1731593928,
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let db = get_db().await;
+        let chain_store = get_chain_store(db.clone()).await;
+        let store = get_store(db.clone()).await;
+        assert!(!store.exists("1234").await);
+        chain_store
+            .add_block("1234", &get_first_block("1234"))
+            .await
+            .unwrap();
+        assert!(!store.exists("1234").await);
+        store
+            .save_keys(
+                "1234",
+                &BillKeys {
+                    private_key: TEST_PRIVATE_KEY_SECP.to_string(),
+                    public_key: TEST_PUB_KEY_SECP.to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.exists("1234").await)
+    }
+
+    #[tokio::test]
+    async fn test_get_ids() {
+        let db = get_db().await;
+        let chain_store = get_chain_store(db.clone()).await;
+        let store = get_store(db.clone()).await;
+        chain_store
+            .add_block("1234", &get_first_block("1234"))
+            .await
+            .unwrap();
+        chain_store
+            .add_block("4321", &get_first_block("4321"))
+            .await
+            .unwrap();
+        let res = store.get_ids().await;
+        assert!(res.is_ok());
+        assert!(res.as_ref().unwrap().contains(&"1234".to_string()));
+        assert!(res.as_ref().unwrap().contains(&"4321".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_save_get_keys() {
+        let store = get_store(get_db().await).await;
+        let res = store
+            .save_keys(
+                "1234",
+                &BillKeys {
+                    private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
+                    public_key: TEST_PUB_KEY_SECP.to_owned(),
+                },
+            )
+            .await;
+        assert!(res.is_ok());
+        let get_res = store.get_keys("1234").await;
+        assert!(get_res.is_ok());
+        assert_eq!(get_res.as_ref().unwrap().private_key, TEST_PRIVATE_KEY_SECP);
+    }
+}

--- a/src/persistence/db/bill.rs
+++ b/src/persistence/db/bill.rs
@@ -2,11 +2,10 @@ use super::Result;
 use crate::{
     constants::{DB_BILL_ID, DB_TABLE},
     persistence::{bill::BillStoreApi, Error},
-    service::bill_service::{Bill, BillKeys},
+    service::bill_service::BillKeys,
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 use surrealdb::{engine::any::Any, sql::Thing, Surreal};
 
 #[derive(Clone)]
@@ -17,80 +16,9 @@ pub struct SurrealBillStore {
 impl SurrealBillStore {
     const CHAIN_TABLE: &'static str = "bill_chain";
     const KEYS_TABLE: &'static str = "bill_keys";
-    // These are in preparation for #330, improving the persistence performance for bills
-    const DATA_TABLE: &'static str = "bill";
-    const PARTICIPANTS_TABLE: &'static str = "bill_participants";
 
     pub fn new(db: Surreal<Any>) -> Self {
         Self { db }
-    }
-
-    #[allow(dead_code)]
-    async fn get(&self, id: &str) -> Result<Bill> {
-        let result: Option<BillDb> = self.db.select((Self::DATA_TABLE, id)).await?;
-        match result {
-            None => Err(Error::NoSuchEntity("bill".to_string(), id.to_owned())),
-            Some(c) => Ok(c.into()),
-        }
-    }
-
-    #[allow(dead_code)]
-    async fn add_participants(&self, id: &str, node_ids: Vec<String>) -> Result<()> {
-        let participants = self.get_participants(id).await?;
-        let to_add: HashSet<String> = node_ids
-            .into_iter()
-            .filter(|n| !participants.iter().any(|p| p == n))
-            .collect();
-        let entities: Vec<BillParticipantDb> = to_add
-            .into_iter()
-            .map(|n| BillParticipantDb {
-                id: None,
-                bill_id: id.to_owned(),
-                node_id: n.clone(),
-            })
-            .collect();
-        let _: Option<BillParticipantDb> = self
-            .db
-            .create(Self::PARTICIPANTS_TABLE)
-            .content(entities)
-            .await?;
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    async fn get_participants(&self, id: &str) -> Result<Vec<String>> {
-        let result: Vec<BillParticipantDb> = self
-            .db
-            .query("SELECT * FROM type::table($table) WHERE bill_id = $bill_id")
-            .bind((DB_TABLE, Self::PARTICIPANTS_TABLE))
-            .bind((DB_BILL_ID, id.to_owned()))
-            .await?
-            .take(0)?;
-        let participants: HashSet<String> = result.into_iter().map(|bp| bp.node_id).collect();
-        Ok(participants.into_iter().collect())
-    }
-
-    #[allow(dead_code)]
-    async fn insert(&self, data: &Bill) -> Result<()> {
-        let id = data.id.to_owned();
-        let entity: BillDb = data.into();
-        let _: Option<BillDb> = self
-            .db
-            .create((Self::DATA_TABLE, id))
-            .content(entity)
-            .await?;
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    async fn update(&self, id: &str, data: &Bill) -> Result<()> {
-        let entity: BillDb = data.into();
-        let _: Option<BillDb> = self
-            .db
-            .update((Self::DATA_TABLE, id))
-            .content(entity)
-            .await?;
-        Ok(())
     }
 }
 
@@ -151,78 +79,6 @@ pub struct BillIdDb {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BillDb {
-    pub id: String,
-    pub drawer_node_id: String,
-    pub payer_node_id: String,
-    pub payee_node_id: String,
-    pub holder_node_id: String,
-    pub place_of_issuing: String,
-    pub issue_date: String,
-    pub maturity_date: String,
-    pub sum: u64,
-    pub currency_code: String,
-    pub place_of_payment: String,
-    pub requested_to_accept: bool,
-    pub accepted: bool,
-    pub requested_to_pay: bool,
-    pub paid: bool,
-    pub payment_address: Option<String>,
-    pub mint_token: Option<String>,
-    pub language: String,
-}
-
-impl From<BillDb> for Bill {
-    fn from(value: BillDb) -> Self {
-        Self {
-            id: value.id,
-            drawer_node_id: value.drawer_node_id,
-            payer_node_id: value.payer_node_id,
-            payee_node_id: value.payee_node_id,
-            holder_node_id: value.holder_node_id,
-            place_of_issuing: value.place_of_issuing,
-            issue_date: value.issue_date,
-            maturity_date: value.maturity_date,
-            sum: value.sum,
-            currency_code: value.currency_code,
-            place_of_payment: value.place_of_payment,
-            requested_to_accept: value.requested_to_accept,
-            accepted: value.accepted,
-            requested_to_pay: value.requested_to_pay,
-            paid: value.paid,
-            payment_address: value.payment_address,
-            mint_token: value.mint_token,
-            language: value.language,
-        }
-    }
-}
-
-impl From<&Bill> for BillDb {
-    fn from(value: &Bill) -> Self {
-        Self {
-            id: value.id.to_owned(),
-            drawer_node_id: value.drawer_node_id.clone(),
-            payer_node_id: value.payer_node_id.clone(),
-            payee_node_id: value.payee_node_id.clone(),
-            holder_node_id: value.holder_node_id.clone(),
-            place_of_issuing: value.place_of_issuing.clone(),
-            issue_date: value.issue_date.clone(),
-            maturity_date: value.maturity_date.clone(),
-            sum: value.sum,
-            currency_code: value.currency_code.clone(),
-            place_of_payment: value.place_of_payment.clone(),
-            requested_to_accept: value.requested_to_accept,
-            accepted: value.accepted,
-            requested_to_pay: value.requested_to_pay,
-            paid: value.paid,
-            payment_address: value.payment_address.clone(),
-            mint_token: value.mint_token.clone(),
-            language: value.language.clone(),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BillKeysDb {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<Thing>,
@@ -247,14 +103,6 @@ impl From<&BillKeys> for BillKeysDb {
             private_key: value.private_key.clone(),
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BillParticipantDb {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<Thing>,
-    pub bill_id: String,
-    pub node_id: String,
 }
 
 #[cfg(test)]

--- a/src/persistence/db/bill_chain.rs
+++ b/src/persistence/db/bill_chain.rs
@@ -1,0 +1,256 @@
+use super::super::{Error, Result};
+use crate::{
+    blockchain::{
+        bill::{BillBlock, BillBlockchain, BillOpCode},
+        Block,
+    },
+    constants::{
+        DB_BILL_ID, DB_BLOCK_ID, DB_DATA, DB_HASH, DB_OP_CODE, DB_PREVIOUS_HASH, DB_PUBLIC_KEY,
+        DB_SIGNATURE, DB_TABLE, DB_TIMESTAMP,
+    },
+    persistence::bill::BillChainStoreApi,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use surrealdb::{engine::any::Any, Surreal};
+
+const CREATE_BLOCK_QUERY: &str = r#"CREATE type::table($table) CONTENT {
+                                    bill_id: $bill_id,
+                                    block_id: $block_id,
+                                    hash: $hash,
+                                    previous_hash: $previous_hash,
+                                    signature: $signature,
+                                    timestamp: $timestamp,
+                                    public_key: $public_key,
+                                    data: $data,
+                                    op_code: $op_code
+                                };"#;
+
+#[derive(Clone)]
+pub struct SurrealBillChainStore {
+    db: Surreal<Any>,
+}
+
+impl SurrealBillChainStore {
+    const TABLE: &'static str = "bill_chain";
+
+    pub fn new(db: Surreal<Any>) -> Self {
+        Self { db }
+    }
+
+    async fn create_block(&self, query: &str, entity: BillBlockDb) -> Result<()> {
+        let _ = self
+            .db
+            .query(query)
+            .bind((DB_TABLE, Self::TABLE))
+            .bind((DB_BILL_ID, entity.bill_id))
+            .bind((DB_BLOCK_ID, entity.block_id))
+            .bind((DB_HASH, entity.hash))
+            .bind((DB_PREVIOUS_HASH, entity.previous_hash))
+            .bind((DB_SIGNATURE, entity.signature))
+            .bind((DB_TIMESTAMP, entity.timestamp))
+            .bind((DB_PUBLIC_KEY, entity.public_key))
+            .bind((DB_DATA, entity.data))
+            .bind((DB_OP_CODE, entity.op_code))
+            .await?
+            .check()?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BillChainStoreApi for SurrealBillChainStore {
+    async fn get_latest_block(&self, id: &str) -> Result<BillBlock> {
+        let result: Vec<BillBlockDb> = self
+            .db
+            .query("SELECT * FROM type::table($table) WHERE bill_id = $bill_id ORDER BY block_id DESC LIMIT 1")
+            .bind((DB_TABLE, Self::TABLE))
+            .bind((DB_BILL_ID, id.to_owned()))
+            .await?
+            .take(0)?;
+
+        match result.first() {
+            None => Err(Error::NoBillBlock),
+            Some(block) => Ok(block.to_owned().into()),
+        }
+    }
+
+    async fn add_block(&self, id: &str, block: &BillBlock) -> Result<()> {
+        let entity: BillBlockDb = block.into();
+        match self.get_latest_block(id).await {
+            Err(Error::NoBillBlock) => {
+                // if there is no latest block, ensure it's a valid first block
+                if block.id == 1 && block.verify() && block.validate_hash() {
+                    // Atomically ensure it's the first block
+                    let query = format!(
+                        r#"
+                        BEGIN TRANSACTION;
+                        LET $blocks = (RETURN count(SELECT * FROM type::table($table) WHERE bill_id = $bill_id));
+                        IF $blocks = 0 AND $block_id = 1 {{
+                            {}
+                        }} ELSE {{
+                            THROW "invalid block - not the first block";
+                        }};
+                        COMMIT TRANSACTION;
+                    "#,
+                        CREATE_BLOCK_QUERY
+                    );
+                    self.create_block(&query, entity).await?;
+                    Ok(())
+                } else {
+                    return Err(Error::AddBillBlock(format!(
+                        "First Block validation error: block id: {}",
+                        block.id
+                    )));
+                }
+            }
+            Ok(latest_block) => {
+                // if there is a latest block, ensure it's a valid follow-up block
+                if !block.validate_with_previous(&latest_block) {
+                    return Err(Error::AddBillBlock(format!(
+                        "Block validation error: block id: {}, latest block id: {}",
+                        block.id, latest_block.id
+                    )));
+                }
+                // Atomically ensure the block is valid
+                let query = format!(
+                    r#"
+                    BEGIN TRANSACTION;
+                    LET $latest_block = (SELECT block_id, hash FROM type::table($table) WHERE bill_id = $bill_id ORDER BY block_id DESC LIMIT 1)[0];
+                    IF $latest_block.block_id + 1 = $block_id AND $latest_block.hash = $previous_hash {{
+                        {}
+                    }} ELSE {{
+                        THROW "invalid block";
+                    }};
+                    COMMIT TRANSACTION;
+                "#,
+                    CREATE_BLOCK_QUERY
+                );
+                self.create_block(&query, entity).await?;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn get_chain(&self, id: &str) -> Result<BillBlockchain> {
+        let result: Vec<BillBlockDb> = self
+            .db
+            .query(
+                "SELECT * FROM type::table($table) WHERE bill_id = $bill_id ORDER BY block_id ASC",
+            )
+            .bind((DB_TABLE, Self::TABLE))
+            .bind((DB_BILL_ID, id.to_owned()))
+            .await?
+            .take(0)?;
+
+        let blocks: Vec<BillBlock> = result.into_iter().map(|b| b.into()).collect();
+        let chain = BillBlockchain::new_from_blocks(blocks)?;
+
+        Ok(chain)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BillBlockDb {
+    pub bill_id: String,
+    pub block_id: u64,
+    pub hash: String,
+    pub previous_hash: String,
+    pub signature: String,
+    pub timestamp: u64,
+    pub public_key: String,
+    pub data: String,
+    pub op_code: BillOpCode,
+}
+
+impl From<BillBlockDb> for BillBlock {
+    fn from(value: BillBlockDb) -> Self {
+        Self {
+            bill_id: value.bill_id,
+            id: value.block_id,
+            hash: value.hash,
+            timestamp: value.timestamp,
+            data: value.data,
+            public_key: value.public_key,
+            previous_hash: value.previous_hash,
+            signature: value.signature,
+            op_code: value.op_code,
+        }
+    }
+}
+
+impl From<&BillBlock> for BillBlockDb {
+    fn from(value: &BillBlock) -> Self {
+        Self {
+            bill_id: value.bill_id.clone(),
+            block_id: value.id,
+            hash: value.hash.clone(),
+            previous_hash: value.previous_hash.clone(),
+            signature: value.signature.clone(),
+            timestamp: value.timestamp,
+            public_key: value.public_key.clone(),
+            data: value.data.clone(),
+            op_code: value.op_code.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        blockchain::{
+            bill::block::{BillAcceptBlockData, BillIdentityBlockData},
+            Blockchain,
+        },
+        persistence::db::{bill::tests::get_first_block, get_memory_db},
+        service::contact_service::ContactType,
+        tests::tests::get_bill_keys,
+        util::BcrKeys,
+    };
+
+    async fn get_store() -> SurrealBillChainStore {
+        let mem_db = get_memory_db("test", "bill_chain")
+            .await
+            .expect("could not create get_memory_db");
+        SurrealBillChainStore::new(mem_db)
+    }
+
+    #[tokio::test]
+    async fn test_chain() {
+        let store = get_store().await;
+        let block = get_first_block("1234");
+        store.add_block("1234", &block).await.unwrap();
+        let last_block = store.get_latest_block("1234").await;
+        assert!(last_block.is_ok());
+        assert_eq!(last_block.as_ref().unwrap().id, 1);
+
+        let block2 = BillBlock::create_block_for_accept(
+            "1234".to_string(),
+            &block,
+            &BillAcceptBlockData {
+                accepter: BillIdentityBlockData {
+                    t: ContactType::Person,
+                    node_id: "555555".to_owned(),
+                    name: "some dude".to_owned(),
+                    postal_address: "address".to_owned(),
+                },
+                signatory: None,
+                signing_timestamp: 1731593928,
+                signing_address: "address".to_owned(),
+            },
+            &BcrKeys::new(),
+            None,
+            &BcrKeys::from_private_key(&get_bill_keys().private_key).unwrap(),
+            1731593928,
+        )
+        .unwrap();
+        store.add_block("1234", &block2).await.unwrap();
+        let last_block = store.get_latest_block("1234").await;
+        assert!(last_block.is_ok());
+        assert_eq!(last_block.as_ref().unwrap().id, 2);
+        let chain = store.get_chain("1234").await.unwrap();
+        assert_eq!(chain.blocks().len(), 2);
+    }
+}

--- a/src/persistence/db/company.rs
+++ b/src/persistence/db/company.rs
@@ -1,4 +1,4 @@
-use super::Result;
+use super::{FileDb, Result};
 use crate::{
     persistence::{company::CompanyStoreApi, Error},
     service::company_service::{Company, CompanyKeys},
@@ -119,12 +119,6 @@ pub struct CompanyDb {
     pub proof_of_registration_file: Option<FileDb>,
     pub logo_file: Option<FileDb>,
     pub signatories: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct FileDb {
-    pub name: String,
-    pub hash: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/persistence/db/mod.rs
+++ b/src/persistence/db/mod.rs
@@ -1,10 +1,13 @@
 use super::Result;
 use log::error;
+use serde::{Deserialize, Serialize};
 use surrealdb::{
     engine::any::{connect, Any},
     Surreal,
 };
 
+pub mod bill;
+pub mod bill_chain;
 pub mod company;
 pub mod company_chain;
 pub mod contact;
@@ -61,6 +64,12 @@ pub async fn get_memory_db(namespace: &str, database: &str) -> Result<Surreal<An
     let db = connect("mem://").await?;
     db.use_ns(namespace).use_db(database).await?;
     Ok(db)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileDb {
+    pub name: String,
+    pub hash: String,
 }
 
 #[cfg(test)]

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -1349,28 +1349,6 @@ impl BillServiceApi for BillService {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Bill {
-    pub id: String,
-    pub drawer_node_id: String,
-    pub payer_node_id: String,
-    pub payee_node_id: String,
-    pub holder_node_id: String,
-    pub place_of_issuing: String,
-    pub issue_date: String,
-    pub maturity_date: String,
-    pub sum: u64,
-    pub currency_code: String,
-    pub place_of_payment: String,
-    pub requested_to_accept: bool,
-    pub accepted: bool,
-    pub requested_to_pay: bool,
-    pub paid: bool,
-    pub payment_address: Option<String>,
-    pub mint_token: Option<String>,
-    pub language: String,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct BitcreditBillToReturn {
     pub id: String,

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -15,6 +15,7 @@ use crate::blockchain::company::{CompanyBlock, CompanySignCompanyBillBlockData};
 use crate::blockchain::identity::{IdentityBlock, IdentitySignPersonBillBlockData};
 use crate::blockchain::{self, Blockchain};
 use crate::external::bitcoin::BitcoinClientApi;
+use crate::persistence::bill::BillChainStoreApi;
 use crate::persistence::company::CompanyChainStoreApi;
 use crate::persistence::file_upload::FileUploadStoreApi;
 use crate::persistence::identity::{IdentityChainStoreApi, IdentityStoreApi};
@@ -28,6 +29,7 @@ use crate::{
 };
 use crate::{error, CONFIG};
 use async_trait::async_trait;
+use borsh::to_vec;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use chrono::Utc;
 use log::info;
@@ -62,10 +64,6 @@ pub enum Error {
     #[error("Caller is not payee, or endorsee")]
     CallerIsNotPayeeOrEndorsee,
 
-    /// errors stemming from json deserialization
-    #[error("unable to serialize/deserialize to/from JSON {0}")]
-    Json(#[from] serde_json::Error),
-
     /// errors that stem from interacting with a blockchain
     #[error("Blockchain error: {0}")]
     Blockchain(#[from] blockchain::Error),
@@ -88,6 +86,9 @@ pub enum Error {
 
     #[error("Notification error: {0}")]
     Notification(#[from] notification_service::Error),
+
+    #[error("io error {0}")]
+    Io(#[from] std::io::Error),
 }
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for Error {
@@ -97,7 +98,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for Error {
             Error::CannotReturnCombinedBitcoinKeyForBill => Status::BadRequest.respond_to(req),
             Error::CallerIsNotDrawee => Status::BadRequest.respond_to(req),
             Error::CallerIsNotPayeeOrEndorsee => Status::BadRequest.respond_to(req),
-            Error::Json(e) => {
+            Error::Io(e) => {
                 error!("{e}");
                 Status::InternalServerError.respond_to(req)
             }
@@ -258,6 +259,7 @@ pub trait BillServiceApi: Send + Sync {
 pub struct BillService {
     client: Client,
     store: Arc<dyn BillStoreApi>,
+    blockchain_store: Arc<dyn BillChainStoreApi>,
     identity_store: Arc<dyn IdentityStoreApi>,
     file_upload_store: Arc<dyn FileUploadStoreApi>,
     bitcoin_client: Arc<dyn BitcoinClientApi>,
@@ -271,6 +273,7 @@ impl BillService {
     pub fn new(
         client: Client,
         store: Arc<dyn BillStoreApi>,
+        blockchain_store: Arc<dyn BillChainStoreApi>,
         identity_store: Arc<dyn IdentityStoreApi>,
         file_upload_store: Arc<dyn FileUploadStoreApi>,
         bitcoin_client: Arc<dyn BitcoinClientApi>,
@@ -282,6 +285,7 @@ impl BillService {
         Self {
             client,
             store,
+            blockchain_store,
             identity_store,
             file_upload_store,
             bitcoin_client,
@@ -298,11 +302,9 @@ impl BillService {
         blockchain: &mut BillBlockchain,
         new_block: BillBlock,
     ) -> Result<()> {
-        let try_add_block = blockchain.try_add_block(new_block);
+        let try_add_block = blockchain.try_add_block(new_block.clone());
         if try_add_block && blockchain.is_chain_valid() {
-            self.store
-                .write_blockchain_to_file(bill_id, blockchain.to_pretty_printed_json()?)
-                .await?;
+            self.blockchain_store.add_block(bill_id, &new_block).await?;
             Ok(())
         } else {
             Err(Error::Blockchain(blockchain::Error::BlockchainInvalid))
@@ -323,7 +325,7 @@ impl BillService {
                 bill_id: bill_id.to_owned(),
                 block_id: block.id,
                 block_hash: block.hash.to_owned(),
-                operation: block.operation_code.clone(),
+                operation: block.op_code.clone(),
             },
             keys,
             timestamp,
@@ -352,7 +354,7 @@ impl BillService {
                 bill_id: bill_id.to_owned(),
                 block_id: block.id,
                 block_hash: block.hash.to_owned(),
-                operation: block.operation_code.clone(),
+                operation: block.op_code.clone(),
             },
             signatory_keys,
             company_keys,
@@ -434,7 +436,6 @@ impl BillService {
         Ok(BitcreditBill {
             id: last_version_bill.id,
             bill_jurisdiction: last_version_bill.bill_jurisdiction,
-            timestamp_at_drawing: last_version_bill.timestamp_at_drawing,
             drawee: drawee_contact,
             drawer: drawer_contact,
             payee: payee_contact,
@@ -456,12 +457,12 @@ impl BillService {
 impl BillServiceApi for BillService {
     async fn get_bills(&self) -> Result<Vec<BitcreditBillToReturn>> {
         let mut res = vec![];
-        let bill_ids = self.store.get_bill_ids().await?;
+        let bill_ids = self.store.get_ids().await?;
         let identity = self.identity_store.get().await?;
 
         for bill_id in bill_ids {
-            let chain = self.store.read_bill_chain_from_file(&bill_id).await?;
-            let bill_keys = self.store.read_bill_keys_from_file(&bill_id).await?;
+            let chain = self.blockchain_store.get_chain(&bill_id).await?;
+            let bill_keys = self.store.get_keys(&bill_id).await?;
             let bill = self
                 .last_version_bill_to_bitcredit_bill(
                     chain.get_last_version_bill(&bill_keys)?,
@@ -500,7 +501,6 @@ impl BillServiceApi for BillService {
             res.push(BitcreditBillToReturn {
                 id: bill.id,
                 bill_jurisdiction: bill.bill_jurisdiction,
-                timestamp_at_drawing: bill.timestamp_at_drawing,
                 drawee: bill.drawee,
                 drawer,
                 payee: bill.payee,
@@ -541,8 +541,8 @@ impl BillServiceApi for BillService {
         bill_id: &str,
     ) -> Result<BillCombinedBitcoinKey> {
         let identity = self.identity_store.get_full().await?;
-        let chain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let chain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
 
         let bill = self
             .last_version_bill_to_bitcredit_bill(
@@ -578,8 +578,8 @@ impl BillServiceApi for BillService {
         current_timestamp: u64,
     ) -> Result<BitcreditBillToReturn> {
         let identity = self.identity_store.get_full().await?;
-        let chain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let chain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 chain.get_last_version_bill(&bill_keys)?,
@@ -691,7 +691,6 @@ impl BillServiceApi for BillService {
         Ok(BitcreditBillToReturn {
             id: bill.id,
             bill_jurisdiction: bill.bill_jurisdiction,
-            timestamp_at_drawing: bill.timestamp_at_drawing,
             drawee: bill.drawee,
             drawer,
             payee: bill.payee,
@@ -725,8 +724,8 @@ impl BillServiceApi for BillService {
     }
 
     async fn get_bill(&self, bill_id: &str) -> Result<BitcreditBill> {
-        let chain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let chain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let identity = self.identity_store.get().await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
@@ -738,7 +737,7 @@ impl BillServiceApi for BillService {
     }
 
     async fn get_blockchain_for_bill(&self, bill_id: &str) -> Result<BillBlockchain> {
-        let chain = self.store.read_bill_chain_from_file(bill_id).await?;
+        let chain = self.blockchain_store.get_chain(bill_id).await?;
         Ok(chain)
     }
 
@@ -752,7 +751,7 @@ impl BillServiceApi for BillService {
     }
 
     async fn get_bill_keys(&self, bill_id: &str) -> Result<BillKeys> {
-        let keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let keys = self.store.get_keys(bill_id).await?;
         Ok(keys)
     }
 
@@ -811,10 +810,12 @@ impl BillServiceApi for BillService {
         let bill_id = util::sha256_hash(public_key.as_bytes());
 
         self.store
-            .write_bill_keys_to_file(
-                bill_id.clone(),
-                keys.get_private_key_string(),
-                public_key.clone(),
+            .save_keys(
+                &bill_id,
+                &BillKeys {
+                    private_key: keys.get_private_key_string(),
+                    public_key: keys.get_public_key(),
+                },
             )
             .await?;
 
@@ -845,7 +846,6 @@ impl BillServiceApi for BillService {
         let bill = BitcreditBill {
             id: bill_id.clone(),
             bill_jurisdiction,
-            timestamp_at_drawing: timestamp,
             place_of_drawing,
             currency_code,
             amount_numbers,
@@ -878,14 +878,14 @@ impl BillServiceApi for BillService {
         };
 
         let chain = BillBlockchain::new(
-            &BillIssueBlockData::from(bill.clone(), signatory_identity),
+            &BillIssueBlockData::from(bill.clone(), signatory_identity, timestamp),
             signatory_keys,
             company_keys,
             keys.clone(),
             timestamp,
         )?;
 
-        let block = chain.get_latest_block();
+        let block = chain.get_first_block();
         match drawer_public_data.t {
             ContactType::Person => {
                 self.add_block_to_identity_chain_for_signed_bill_action(
@@ -912,10 +912,7 @@ impl BillServiceApi for BillService {
             }
         }
 
-        let json_chain = serde_json::to_string_pretty(&chain)?;
-        self.store
-            .write_blockchain_to_file(&bill.id, json_chain)
-            .await?;
+        self.blockchain_store.add_block(&bill.id, block).await?;
 
         // clean up temporary file uploads, if there are any, logging any errors
         if let Some(ref upload_id) = file_upload_id {
@@ -937,7 +934,7 @@ impl BillServiceApi for BillService {
     }
 
     async fn propagate_block(&self, bill_id: &str, block: &BillBlock) -> Result<()> {
-        let block_bytes = serde_json::to_vec(block)?;
+        let block_bytes = to_vec(block)?;
         let event = GossipsubEvent::new(GossipsubEventId::BillBlock, block_bytes);
         let message = event.to_byte_array()?;
 
@@ -980,9 +977,9 @@ impl BillServiceApi for BillService {
     async fn accept_bill(&self, bill_id: &str, timestamp: u64) -> Result<BillBlockchain> {
         let identity = self.identity_store.get_full().await?;
         let my_node_id = identity.identity.node_id.clone();
-        let mut blockchain = self.store.read_bill_chain_from_file(bill_id).await?;
+        let mut blockchain = self.blockchain_store.get_chain(bill_id).await?;
 
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 blockchain.get_last_version_bill(&bill_keys)?,
@@ -1047,8 +1044,8 @@ impl BillServiceApi for BillService {
     ) -> Result<BillBlockchain> {
         let identity = self.identity_store.get_full().await?;
         let my_node_id = identity.identity.node_id.clone();
-        let mut blockchain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let mut blockchain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 blockchain.get_last_version_bill(&bill_keys)?,
@@ -1104,8 +1101,8 @@ impl BillServiceApi for BillService {
     async fn request_acceptance(&self, bill_id: &str, timestamp: u64) -> Result<BillBlockchain> {
         let identity = self.identity_store.get_full().await?;
         let my_node_id = identity.identity.node_id.clone();
-        let mut blockchain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let mut blockchain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 blockchain.get_last_version_bill(&bill_keys)?,
@@ -1167,8 +1164,8 @@ impl BillServiceApi for BillService {
     ) -> Result<BillBlockchain> {
         let identity = self.identity_store.get_full().await?;
         let my_node_id = identity.identity.node_id.clone();
-        let mut blockchain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let mut blockchain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 blockchain.get_last_version_bill(&bill_keys)?,
@@ -1233,8 +1230,8 @@ impl BillServiceApi for BillService {
     ) -> Result<BillBlockchain> {
         let identity = self.identity_store.get_full().await?;
         let my_node_id = identity.identity.node_id.clone();
-        let mut blockchain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let mut blockchain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 blockchain.get_last_version_bill(&bill_keys)?,
@@ -1297,8 +1294,8 @@ impl BillServiceApi for BillService {
     ) -> Result<BillBlockchain> {
         let identity = self.identity_store.get_full().await?;
         let my_node_id = identity.identity.node_id.clone();
-        let mut blockchain = self.store.read_bill_chain_from_file(bill_id).await?;
-        let bill_keys = self.store.read_bill_keys_from_file(bill_id).await?;
+        let mut blockchain = self.blockchain_store.get_chain(bill_id).await?;
+        let bill_keys = self.store.get_keys(bill_id).await?;
         let bill = self
             .last_version_bill_to_bitcredit_bill(
                 blockchain.get_last_version_bill(&bill_keys)?,
@@ -1352,11 +1349,32 @@ impl BillServiceApi for BillService {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Bill {
+    pub id: String,
+    pub drawer_node_id: String,
+    pub payer_node_id: String,
+    pub payee_node_id: String,
+    pub holder_node_id: String,
+    pub place_of_issuing: String,
+    pub issue_date: String,
+    pub maturity_date: String,
+    pub sum: u64,
+    pub currency_code: String,
+    pub place_of_payment: String,
+    pub requested_to_accept: bool,
+    pub accepted: bool,
+    pub requested_to_pay: bool,
+    pub paid: bool,
+    pub payment_address: Option<String>,
+    pub mint_token: Option<String>,
+    pub language: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
 pub struct BitcreditBillToReturn {
     pub id: String,
     pub bill_jurisdiction: String,
-    pub timestamp_at_drawing: u64,
     /// The party obliged to pay a Bill
     pub drawee: IdentityPublicData,
     /// The party issuing a Bill
@@ -1408,7 +1426,6 @@ pub struct BitcreditEbillQuote {
 pub struct BitcreditBill {
     pub id: String,
     pub bill_jurisdiction: String,
-    pub timestamp_at_drawing: u64,
     // The party obliged to pay a Bill
     pub drawee: IdentityPublicData,
     // The party issuing a Bill
@@ -1436,7 +1453,6 @@ impl BitcreditBill {
         Self {
             id: "".to_string(),
             bill_jurisdiction: "".to_string(),
-            timestamp_at_drawing: 0,
             drawee: IdentityPublicData::new_empty(),
             drawer: IdentityPublicData::new_empty(),
             payee: IdentityPublicData::new_empty(),
@@ -1454,7 +1470,7 @@ impl BitcreditBill {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone)]
 pub struct BillKeys {
     pub private_key: String,
     pub public_key: String,
@@ -1477,7 +1493,7 @@ pub mod tests {
     use futures::channel::mpsc;
     use mockall::predicate::{always, eq};
     use persistence::{
-        bill::MockBillStoreApi,
+        bill::{MockBillChainStoreApi, MockBillStoreApi},
         company::{MockCompanyChainStoreApi, MockCompanyStoreApi},
         contact::MockContactStoreApi,
         db::contact::tests::get_baseline_contact,
@@ -1512,7 +1528,7 @@ pub mod tests {
     pub fn get_genesis_chain(bill: Option<BitcreditBill>) -> BillBlockchain {
         let bill = bill.unwrap_or(get_baseline_bill("some id"));
         BillBlockchain::new(
-            &BillIssueBlockData::from(bill, None),
+            &BillIssueBlockData::from(bill, None, 1731593928),
             get_baseline_identity().key_pair,
             None,
             BcrKeys::from_private_key(TEST_PRIVATE_KEY_SECP).unwrap(),
@@ -1523,6 +1539,7 @@ pub mod tests {
 
     fn get_service(
         mock_storage: MockBillStoreApi,
+        mock_chain_storage: MockBillChainStoreApi,
         mock_identity_storage: MockIdentityStoreApi,
         mock_file_upload_storage: MockFileUploadStoreApi,
         mock_identity_chain_storage: MockIdentityChainStoreApi,
@@ -1531,6 +1548,7 @@ pub mod tests {
     ) -> BillService {
         get_service_base(
             mock_storage,
+            mock_chain_storage,
             mock_identity_storage,
             mock_file_upload_storage,
             mock_identity_chain_storage,
@@ -1542,6 +1560,7 @@ pub mod tests {
 
     fn get_service_base(
         mock_storage: MockBillStoreApi,
+        mock_chain_storage: MockBillChainStoreApi,
         mock_identity_storage: MockIdentityStoreApi,
         mock_file_upload_storage: MockFileUploadStoreApi,
         mock_identity_chain_storage: MockIdentityChainStoreApi,
@@ -1562,12 +1581,14 @@ pub mod tests {
             Client::new(
                 sender,
                 Arc::new(MockBillStoreApi::new()),
+                Arc::new(MockBillChainStoreApi::new()),
                 Arc::new(MockCompanyStoreApi::new()),
                 Arc::new(MockCompanyChainStoreApi::new()),
                 Arc::new(MockIdentityStoreApi::new()),
                 Arc::new(MockFileUploadStoreApi::new()),
             ),
             Arc::new(mock_storage),
+            Arc::new(mock_chain_storage),
             Arc::new(mock_identity_storage),
             Arc::new(mock_file_upload_storage),
             Arc::new(bitcoin_client),
@@ -1580,6 +1601,7 @@ pub mod tests {
 
     fn get_storages() -> (
         MockBillStoreApi,
+        MockBillChainStoreApi,
         MockIdentityStoreApi,
         MockFileUploadStoreApi,
         MockIdentityChainStoreApi,
@@ -1614,6 +1636,7 @@ pub mod tests {
             .returning(|_, _| Ok(()));
         (
             MockBillStoreApi::new(),
+            MockBillChainStoreApi::new(),
             MockIdentityStoreApi::new(),
             MockFileUploadStoreApi::new(),
             identity_chain_store,
@@ -1626,6 +1649,7 @@ pub mod tests {
     async fn issue_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             mut file_upload_storage,
             identity_chain_store,
@@ -1644,12 +1668,8 @@ pub mod tests {
         file_upload_storage
             .expect_save_attached_file()
             .returning(move |_, _, _| Ok(()));
-        storage
-            .expect_write_bill_keys_to_file()
-            .returning(|_, _, _| Ok(()));
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
+        storage.expect_save_keys().returning(|_, _| Ok(()));
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
         identity_storage
             .expect_get_key_pair()
             .returning(|| Ok(get_baseline_identity().key_pair));
@@ -1663,6 +1683,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1701,6 +1722,7 @@ pub mod tests {
     async fn save_encrypt_open_decrypt_compare_hashes() {
         let (
             storage,
+            chain_storage,
             identity_storage,
             mut file_upload_storage,
             identity_chain_store,
@@ -1726,6 +1748,7 @@ pub mod tests {
             .returning(move |_, _| Ok(expected_encrypted.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1754,6 +1777,7 @@ pub mod tests {
     async fn save_encrypt_propagates_write_file_error() {
         let (
             storage,
+            chain_storage,
             identity_storage,
             mut file_upload_storage,
             identity_chain_store,
@@ -1770,6 +1794,7 @@ pub mod tests {
             });
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1787,6 +1812,7 @@ pub mod tests {
     async fn open_decrypt_propagates_read_file_error() {
         let (
             storage,
+            chain_storage,
             identity_storage,
             mut file_upload_storage,
             identity_chain_store,
@@ -1803,6 +1829,7 @@ pub mod tests {
             });
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1820,13 +1847,14 @@ pub mod tests {
     async fn get_bill_keys_calls_storage() {
         let (
             mut storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
             company_chain_store,
             contact_storage,
         ) = get_storages();
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
@@ -1834,6 +1862,7 @@ pub mod tests {
         });
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1856,13 +1885,14 @@ pub mod tests {
     async fn get_bill_keys_propagates_errors() {
         let (
             mut storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
             company_chain_store,
             contact_storage,
         ) = get_storages();
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Err(persistence::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "test error",
@@ -1870,6 +1900,7 @@ pub mod tests {
         });
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1884,6 +1915,7 @@ pub mod tests {
     async fn get_bills_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1896,17 +1928,17 @@ pub mod tests {
         identity_storage
             .expect_get()
             .returning(|| Ok(get_baseline_identity().identity));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(|_| Ok(get_genesis_chain(None)));
         storage
-            .expect_get_bill_ids()
+            .expect_get_ids()
             .returning(|| Ok(vec!["some id".to_string()]));
 
         notification_service
@@ -1916,6 +1948,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1935,18 +1968,20 @@ pub mod tests {
     async fn get_bills_empty_for_no_bills() {
         let (
             mut storage,
+            chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
             company_chain_store,
             contact_storage,
         ) = get_storages();
-        storage.expect_get_bill_ids().returning(|| Ok(vec![]));
+        storage.expect_get_ids().returning(|| Ok(vec![]));
         identity_storage
             .expect_get()
             .returning(|| Ok(get_baseline_identity().identity));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1963,6 +1998,7 @@ pub mod tests {
     async fn get_full_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -1974,14 +2010,14 @@ pub mod tests {
         let mut bill = get_baseline_bill("some id");
         bill.drawee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
         let drawee_node_id = bill.drawee.node_id.clone();
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -1993,6 +2029,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2011,6 +2048,7 @@ pub mod tests {
     async fn accept_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2020,17 +2058,15 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.drawee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2045,6 +2081,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2056,13 +2093,14 @@ pub mod tests {
         let res = service.accept_bill("some id", 1731593928).await;
         assert!(res.is_ok());
         assert!(res.as_ref().unwrap().blocks().len() == 2);
-        assert!(res.unwrap().blocks()[1].operation_code == BillOpCode::Accept);
+        assert!(res.unwrap().blocks()[1].op_code == BillOpCode::Accept);
     }
 
     #[tokio::test]
     async fn accept_bill_fails_if_drawee_not_caller() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2072,7 +2110,7 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.drawee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
@@ -2081,11 +2119,12 @@ pub mod tests {
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2101,6 +2140,7 @@ pub mod tests {
     async fn accept_bill_fails_if_already_accepted() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2114,7 +2154,7 @@ pub mod tests {
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
@@ -2135,11 +2175,12 @@ pub mod tests {
             )
             .unwrap(),
         );
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(chain.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2155,6 +2196,7 @@ pub mod tests {
     async fn request_pay_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2164,17 +2206,15 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2189,6 +2229,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2200,13 +2241,14 @@ pub mod tests {
         let res = service.request_pay("some id", "sat", 1731593928).await;
         assert!(res.is_ok());
         assert!(res.as_ref().unwrap().blocks().len() == 2);
-        assert!(res.unwrap().blocks()[1].operation_code == BillOpCode::RequestToPay);
+        assert!(res.unwrap().blocks()[1].op_code == BillOpCode::RequestToPay);
     }
 
     #[tokio::test]
     async fn request_pay_fails_if_payee_not_caller() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2216,20 +2258,21 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2245,6 +2288,7 @@ pub mod tests {
     async fn request_acceptance_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2254,17 +2298,15 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2279,6 +2321,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2290,13 +2333,14 @@ pub mod tests {
         let res = service.request_acceptance("some id", 1731593928).await;
         assert!(res.is_ok());
         assert!(res.as_ref().unwrap().blocks().len() == 2);
-        assert!(res.unwrap().blocks()[1].operation_code == BillOpCode::RequestToAccept);
+        assert!(res.unwrap().blocks()[1].op_code == BillOpCode::RequestToAccept);
     }
 
     #[tokio::test]
     async fn request_acceptance_fails_if_payee_not_caller() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2306,20 +2350,21 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2335,6 +2380,7 @@ pub mod tests {
     async fn mint_bitcredit_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2344,17 +2390,15 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2369,6 +2413,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2388,13 +2433,14 @@ pub mod tests {
             .await;
         assert!(res.is_ok());
         assert!(res.as_ref().unwrap().blocks().len() == 2);
-        assert!(res.unwrap().blocks()[1].operation_code == BillOpCode::Mint);
+        assert!(res.unwrap().blocks()[1].op_code == BillOpCode::Mint);
     }
 
     #[tokio::test]
     async fn mint_bitcredit_bill_fails_if_payee_not_caller() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2404,20 +2450,21 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2441,6 +2488,7 @@ pub mod tests {
     async fn sell_bitcredit_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2450,17 +2498,15 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2475,6 +2521,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2494,13 +2541,14 @@ pub mod tests {
             .await;
         assert!(res.is_ok());
         assert!(res.as_ref().unwrap().blocks().len() == 2);
-        assert!(res.unwrap().blocks()[1].operation_code == BillOpCode::Sell);
+        assert!(res.unwrap().blocks()[1].op_code == BillOpCode::Sell);
     }
 
     #[tokio::test]
     async fn sell_bitcredit_bill_fails_if_payee_not_caller() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2510,20 +2558,21 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2547,6 +2596,7 @@ pub mod tests {
     async fn endorse_bitcredit_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2556,17 +2606,15 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(identity.identity.node_id.clone());
-        storage
-            .expect_write_blockchain_to_file()
-            .returning(|_, _| Ok(()));
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        chain_storage.expect_add_block().returning(|_, _| Ok(()));
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2581,6 +2629,7 @@ pub mod tests {
 
         let service = get_service_base(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2598,13 +2647,14 @@ pub mod tests {
             .await;
         assert!(res.is_ok());
         assert!(res.as_ref().unwrap().blocks().len() == 2);
-        assert!(res.unwrap().blocks()[1].operation_code == BillOpCode::Endorse);
+        assert!(res.unwrap().blocks()[1].op_code == BillOpCode::Endorse);
     }
 
     #[tokio::test]
     async fn endorse_bitcredit_bill_fails_if_payee_not_caller() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2614,20 +2664,21 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
             .returning(move || Ok(identity.clone()));
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2645,6 +2696,7 @@ pub mod tests {
     async fn get_combined_bitcoin_key_for_bill_baseline() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2655,14 +2707,14 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(identity.key_pair.get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2670,6 +2722,7 @@ pub mod tests {
 
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2685,6 +2738,7 @@ pub mod tests {
     async fn get_combined_bitcoin_key_for_bill_err() {
         let (
             mut storage,
+            mut chain_storage,
             mut identity_storage,
             file_upload_storage,
             identity_chain_store,
@@ -2695,14 +2749,14 @@ pub mod tests {
         let identity = get_baseline_identity();
         let mut bill = get_baseline_bill("some id");
         bill.payee = IdentityPublicData::new_only_node_id(BcrKeys::new().get_public_key());
-        storage.expect_read_bill_keys_from_file().returning(|_| {
+        storage.expect_get_keys().returning(|_| {
             Ok(BillKeys {
                 private_key: TEST_PRIVATE_KEY_SECP.to_owned(),
                 public_key: TEST_PUB_KEY_SECP.to_owned(),
             })
         });
-        storage
-            .expect_read_bill_chain_from_file()
+        chain_storage
+            .expect_get_chain()
             .returning(move |_| Ok(get_genesis_chain(Some(bill.clone()))));
         identity_storage
             .expect_get_full()
@@ -2710,6 +2764,7 @@ pub mod tests {
 
         let service = get_service(
             storage,
+            chain_storage,
             identity_storage,
             file_upload_storage,
             identity_chain_store,

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -571,39 +571,6 @@ pub struct Company {
     pub signatories: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
-pub struct CompanyPublicData {
-    pub id: String,
-    pub name: String,
-    pub postal_address: String,
-    pub email: String,
-    pub public_key: String,
-}
-
-impl CompanyPublicData {
-    pub fn from_all(id: String, company: Company, company_keys: CompanyKeys) -> CompanyPublicData {
-        CompanyPublicData {
-            id,
-            name: company.name,
-            postal_address: company.postal_address,
-            email: company.email,
-            public_key: company_keys.public_key,
-        }
-    }
-}
-
-impl From<CompanyToReturn> for CompanyPublicData {
-    fn from(company: CompanyToReturn) -> Self {
-        Self {
-            id: company.id,
-            name: company.name,
-            postal_address: company.postal_address,
-            email: company.email,
-            public_key: company.public_key,
-        }
-    }
-}
-
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, Clone)]
 pub struct CompanyKeys {
     pub private_key: String,

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -201,12 +201,21 @@ impl CompanyServiceApi for CompanyService {
 
         let full_identity = self.identity_store.get_full().await?;
 
+        // Save the files locally with the identity public key
         let proof_of_registration_file = self
-            .process_upload_file(&proof_of_registration_file_upload_id, &id, &public_key)
+            .process_upload_file(
+                &proof_of_registration_file_upload_id,
+                &id,
+                &full_identity.key_pair.get_public_key(),
+            )
             .await?;
 
         let logo_file = self
-            .process_upload_file(&logo_file_upload_id, &id, &public_key)
+            .process_upload_file(
+                &logo_file_upload_id,
+                &id,
+                &full_identity.key_pair.get_public_key(),
+            )
             .await?;
 
         self.store.save_key_pair(&id, &company_keys).await?;

--- a/src/service/notification_service/test_utils.rs
+++ b/src/service/notification_service/test_utils.rs
@@ -1,6 +1,6 @@
 use crate::{
     persistence::{
-        bill::MockBillStoreApi,
+        bill::{MockBillChainStoreApi, MockBillStoreApi},
         company::{MockCompanyChainStoreApi, MockCompanyStoreApi},
         contact::MockContactStoreApi,
         file_upload::MockFileUploadStoreApi,
@@ -146,6 +146,7 @@ pub fn get_mock_db_context() -> DbContext {
     DbContext {
         contact_store: Arc::new(MockContactStoreApi::new()),
         bill_store: Arc::new(MockBillStoreApi::new()),
+        bill_blockchain_store: Arc::new(MockBillChainStoreApi::new()),
         identity_store: Arc::new(MockIdentityStoreApi::new()),
         identity_chain_store: Arc::new(MockIdentityChainStoreApi::new()),
         company_store: Arc::new(MockCompanyStoreApi::new()),

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -513,37 +513,6 @@ pub async fn accept_bill(
 
 // Mint
 
-//PUT
-// #[post("/try_mint", format = "json", data = "<mint_bill_payload>")]
-// pub async fn try_mint_bill(
-//     state: &State<ServiceContext>,
-//     mint_bill_payload: Json<MintBitcreditBillPayload>,
-// ) -> Status {
-//     if !state.identity_service.identity_exists().await {
-//         Err(service::Error::PreconditionFailed)
-//     } else {
-//         let mut client = state.inner().clone();
-//
-//         let public_mint_node =
-//             get_identity_public_data(mint_bill_payload.mint_node.clone(), client.clone()).await;
-//
-//         if !public_mint_node.name.is_empty() {
-//             client
-//                 .add_bill_to_dht_for_node(
-//                     &mint_bill_payload.bill_id,
-//                     &public_mint_node.node_id.to_string().clone(),
-//                 )
-//                 .await;
-//
-//             Status::Ok
-//         } else {
-//             Status::NotAcceptable
-//         }
-//     }
-// }
-
-//PUT
-//TODO: add try_mint_bill here?
 #[put(
     "/request_to_mint",
     format = "json",

--- a/src/web/handlers/company/mod.rs
+++ b/src/web/handlers/company/mod.rs
@@ -1,11 +1,7 @@
 use crate::{
     dht::{GossipsubEvent, GossipsubEventId},
     external,
-    service::{
-        self,
-        company_service::{CompanyPublicData, CompanyToReturn},
-        Error, Result, ServiceContext,
-    },
+    service::{self, company_service::CompanyToReturn, Error, Result, ServiceContext},
     util::file::{detect_content_type_for_bytes, UploadFileHandler},
     web::data::{UploadFileForm, UploadFilesResponse},
 };
@@ -128,9 +124,6 @@ pub async fn create(
         .await?;
     dht_client.subscribe_to_company_topic(id).await?;
     dht_client.start_providing_company(id).await?;
-    dht_client
-        .put_company_public_data_in_dht(CompanyPublicData::from(created_company.clone()))
-        .await?;
 
     Ok(Json(created_company))
 }
@@ -159,12 +152,6 @@ pub async fn edit(
             payload.logo_file_upload_id,
             timestamp,
         )
-        .await?;
-
-    let updated = state.company_service.get_company_by_id(&payload.id).await?;
-    let mut dht_client = state.dht_client();
-    dht_client
-        .put_company_public_data_in_dht(CompanyPublicData::from(updated))
         .await?;
 
     Ok(Status::Ok)

--- a/src/web/handlers/quotes.rs
+++ b/src/web/handlers/quotes.rs
@@ -39,10 +39,7 @@ pub async fn accept_quote(
         .await?;
 
     if let Some(endorsee) = public_data_endorsee {
-        let timestamp = external::time::TimeApi::get_atomic_time()
-            .await
-            .unwrap()
-            .timestamp;
+        let timestamp = external::time::TimeApi::get_atomic_time().await?.timestamp;
         state
             .bill_service
             .endorse_bitcredit_bill(&quote.bill_id, endorsee.clone(), timestamp)


### PR DESCRIPTION
## 📝 Description

* Removed `timestamp_at_drawing`, because it's a duplicate field
* Removed unused logic to put/get company data to/from DHT
* Move Bills persistence from files to SurrealDB
* Fix company file encryption (used the wrong pub key during a refactoring)
* Use borsh for all network comms except for Web API

Relates to #250 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Create bills with several clients, making sure that the bills are now persisted in surrealdb instead of the file system

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #250 


## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
