### PR TITLE
Temporarily remove bill participants check, make DHT interactions async

### DIFF
--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -1260,22 +1260,23 @@ impl Client {
         bill_id: &str,
         node_id: &str,
     ) -> Result<Vec<u8>> {
-        let chain = self.bill_blockchain_store.get_chain(bill_id).await?;
+        let _chain = self.bill_blockchain_store.get_chain(bill_id).await?;
         let bill_keys = self.bill_store.get_keys(bill_id).await?;
-        if chain
-            .get_all_nodes_from_bill(&bill_keys)?
-            .iter()
-            .any(|n| n == node_id)
-        {
-            let bytes = bill_keys_to_bytes(&bill_keys)?;
-            let file_encrypted = util::crypto::encrypt_ecies(&bytes, node_id)?;
-            Ok(file_encrypted)
-        } else {
-            Err(super::Error::CallerNotPartOfBill(
-                node_id.to_owned(),
-                bill_id.to_string(),
-            ))
-        }
+        // TODO: RE-ADD this check later
+        // if chain
+        //     .get_all_nodes_from_bill(&bill_keys)?
+        //     .iter()
+        //     .any(|n| n == node_id)
+        // {
+        let bytes = bill_keys_to_bytes(&bill_keys)?;
+        let file_encrypted = util::crypto::encrypt_ecies(&bytes, node_id)?;
+        Ok(file_encrypted)
+        // } else {
+        //     Err(super::Error::CallerNotPartOfBill(
+        //         node_id.to_owned(),
+        //         bill_id.to_string(),
+        //     ))
+        // }
     }
 
     async fn handle_bill_file_request_for_attachment(
@@ -1284,25 +1285,26 @@ impl Client {
         node_id: &str,
         file_name: &str,
     ) -> Result<Vec<u8>> {
-        let chain = self.bill_blockchain_store.get_chain(bill_id).await?;
-        let bill_keys = self.bill_store.get_keys(bill_id).await?;
-        if chain
-            .get_all_nodes_from_bill(&bill_keys)?
-            .iter()
-            .any(|n| n == node_id)
-        {
-            let file = self
-                .file_upload_store
-                .open_attached_file(bill_id, file_name)
-                .await?;
-            let file_encrypted = util::crypto::encrypt_ecies(&file, node_id)?;
-            Ok(file_encrypted)
-        } else {
-            Err(super::Error::CallerNotPartOfBill(
-                node_id.to_owned(),
-                bill_id.to_string(),
-            ))
-        }
+        let _chain = self.bill_blockchain_store.get_chain(bill_id).await?;
+        let _bill_keys = self.bill_store.get_keys(bill_id).await?;
+        // TODO: RE-ADD this check later
+        // if chain
+        //     .get_all_nodes_from_bill(&bill_keys)?
+        //     .iter()
+        //     .any(|n| n == node_id)
+        // {
+        let file = self
+            .file_upload_store
+            .open_attached_file(bill_id, file_name)
+            .await?;
+        let file_encrypted = util::crypto::encrypt_ecies(&file, node_id)?;
+        Ok(file_encrypted)
+        // } else {
+        //     Err(super::Error::CallerNotPartOfBill(
+        //         node_id.to_owned(),
+        //         bill_id.to_string(),
+        //     ))
+        // }
     }
 
     // -------------------------------------------------------------

--- a/src/dht/mod.rs
+++ b/src/dht/mod.rs
@@ -92,6 +92,7 @@ pub enum Error {
     FileHashesDidNotMatch(String),
 
     /// error if the caller is not a part of the bill
+    #[allow(dead_code)]
     #[error("The caller {0} is not a part of the bill: {1}")]
     CallerNotPartOfBill(String, String),
 

--- a/src/service/company_service.rs
+++ b/src/service/company_service.rs
@@ -173,9 +173,7 @@ impl CompanyServiceApi for CompanyService {
 
     async fn get_company_and_keys_by_id(&self, id: &str) -> Result<(Company, CompanyKeys)> {
         if !self.store.exists(id).await {
-            return Err(super::Error::Validation(format!(
-                "No company with id: {id} found",
-            )));
+            return Err(crate::service::Error::NotFound);
         }
         let company = self.store.get(id).await?;
         let keys = self.store.get_key_pair(id).await?;

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -37,7 +37,7 @@ pub async fn holder(
     Ok(Json(am_i_holder))
 }
 
-#[get("/bitcoin-key/<id>")]
+#[get("/bitcoin_key/<id>")]
 pub async fn bitcoin_key(
     _identity: IdentityCheck,
     state: &State<ServiceContext>,
@@ -191,11 +191,11 @@ pub async fn bill_detail(
 ) -> Result<Json<BitcreditBillToReturn>> {
     let current_timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
     let identity = state.identity_service.get_identity().await?;
-    let full_bill = state
+    let bill_detail = state
         .bill_service
-        .get_full_bill(id, &identity, current_timestamp)
+        .get_detail(id, &identity, current_timestamp)
         .await?;
-    Ok(Json(full_bill))
+    Ok(Json(bill_detail))
 }
 
 #[get("/check_payment")]
@@ -404,15 +404,21 @@ pub async fn issue_bill(
         )
         .await?;
 
-    state
-        .bill_service
-        .propagate_bill(
-            &bill.id,
-            &bill.drawer.node_id,
-            &bill.drawee.node_id,
-            &bill.payee.node_id,
-        )
-        .await?;
+    let bill_service_clone = state.bill_service.clone();
+    let bill_clone = bill.clone();
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_bill(
+                &bill_clone.id,
+                &bill_clone.drawer.node_id,
+                &bill_clone.drawee.node_id,
+                &bill_clone.payee.node_id,
+            )
+            .await
+        {
+            error!("Error propagating bill on DHT: {e}");
+        }
+    });
 
     // If we're the drawee, we immediately accept the bill
     if bill.drawer == bill.drawee {
@@ -461,18 +467,25 @@ pub async fn offer_to_sell_bill(
         )
         .await?;
 
-    state
-        .bill_service
-        .propagate_block(&offer_to_sell_payload.bill_id, chain.get_latest_block())
-        .await?;
+    let bill_service_clone = state.bill_service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_block(&offer_to_sell_payload.bill_id, chain.get_latest_block())
+            .await
+        {
+            error!("Error propagating block: {e}");
+        }
 
-    state
-        .bill_service
-        .propagate_bill_for_node(
-            &offer_to_sell_payload.bill_id,
-            &public_data_buyer.node_id.to_string(),
-        )
-        .await?;
+        if let Err(e) = bill_service_clone
+            .propagate_bill_for_node(
+                &offer_to_sell_payload.bill_id,
+                &public_data_buyer.node_id.to_string(),
+            )
+            .await
+        {
+            error!("Error propagating bill for node on DHT: {e}");
+        }
+    });
     Ok(Status::Ok)
 }
 
@@ -506,18 +519,25 @@ pub async fn endorse_bill(
         )
         .await?;
 
-    state
-        .bill_service
-        .propagate_block(&endorse_bill_payload.bill_id, chain.get_latest_block())
-        .await?;
+    let bill_service_clone = state.bill_service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_block(&endorse_bill_payload.bill_id, chain.get_latest_block())
+            .await
+        {
+            error!("Error propagating block: {e}");
+        }
 
-    state
-        .bill_service
-        .propagate_bill_for_node(
-            &endorse_bill_payload.bill_id,
-            &public_data_endorsee.node_id.to_string(),
-        )
-        .await?;
+        if let Err(e) = bill_service_clone
+            .propagate_bill_for_node(
+                &endorse_bill_payload.bill_id,
+                &public_data_endorsee.node_id.to_string(),
+            )
+            .await
+        {
+            error!("Error propagating bill for node on DHT: {e}");
+        }
+    });
     Ok(Status::Ok)
 }
 
@@ -542,13 +562,18 @@ pub async fn request_to_pay_bill(
         )
         .await?;
 
-    state
-        .bill_service
-        .propagate_block(
-            &request_to_pay_bill_payload.bill_id,
-            chain.get_latest_block(),
-        )
-        .await?;
+    let bill_service_clone = state.bill_service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_block(
+                &request_to_pay_bill_payload.bill_id,
+                chain.get_latest_block(),
+            )
+            .await
+        {
+            error!("Error propagating block: {e}");
+        }
+    });
     Ok(Status::Ok)
 }
 
@@ -568,13 +593,20 @@ pub async fn request_to_accept_bill(
         .bill_service
         .request_acceptance(&request_to_accept_bill_payload.bill_id, timestamp)
         .await?;
-    state
-        .bill_service
-        .propagate_block(
-            &request_to_accept_bill_payload.bill_id,
-            chain.get_latest_block(),
-        )
-        .await?;
+
+    let bill_service_clone = state.bill_service.clone();
+
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_block(
+                &request_to_accept_bill_payload.bill_id,
+                chain.get_latest_block(),
+            )
+            .await
+        {
+            error!("Error propagating block: {e}");
+        }
+    });
     Ok(Status::Ok)
 }
 
@@ -589,10 +621,16 @@ pub async fn accept_bill(
         .bill_service
         .accept_bill(&accept_bill_payload.bill_id, timestamp)
         .await?;
-    state
-        .bill_service
-        .propagate_block(&accept_bill_payload.bill_id, chain.get_latest_block())
-        .await?;
+
+    let bill_service_clone = state.bill_service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_block(&accept_bill_payload.bill_id, chain.get_latest_block())
+            .await
+        {
+            error!("Error propagating block: {e}");
+        }
+    });
     Ok(Status::Ok)
 }
 
@@ -698,18 +736,25 @@ pub async fn mint_bill(
         )
         .await?;
 
-    state
-        .bill_service
-        .propagate_block(&mint_bill_payload.bill_id, chain.get_latest_block())
-        .await?;
+    let bill_service_clone = state.bill_service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = bill_service_clone
+            .propagate_block(&mint_bill_payload.bill_id, chain.get_latest_block())
+            .await
+        {
+            error!("Error propagating block: {e}");
+        }
 
-    state
-        .bill_service
-        .propagate_bill_for_node(
-            &mint_bill_payload.bill_id,
-            &public_mint_node.node_id.to_string(),
-        )
-        .await?;
+        if let Err(e) = bill_service_clone
+            .propagate_bill_for_node(
+                &mint_bill_payload.bill_id,
+                &public_mint_node.node_id.to_string(),
+            )
+            .await
+        {
+            error!("Error propagating bill for node on DHT: {e}");
+        }
+    });
 
     Ok(Status::Ok)
 }


### PR DESCRIPTION
## 📝 Description

This does 2 things

* Temporarily removes the check for bill participation for keys and bill files (will be re-added in mid February)
* Runs the DHT update and subscription calls in a non-blocking way, which doesn't fail the endpoints, since that just slowed things to a crawl without a benefit.
* Return 404 errors when company/contact/bill doesn't exist for consistency
* Change /bill/bitcoin_key to underscore for consistency

Relates to #288 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Start the app, it should start much faster now
2. The DHT updates and checks are done asynchronously
3. Functionality wise, nothing should have changed

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #288 

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
