### PR TITLE
add specific config flag for bitcoin network

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ The following options are available:
 * `DATA_DIR` - the data directory root (default: ".")
 * `SURREAL_DB_CONNECTION` - the surreal DB connection (default: "ws://localhost:8800") - set to `rocksdb://data/surreal` for embedded mode
 * `TERMINAL_CLIENT` - whether to start a debug terminal client (default: false)
-* `ENVIRONMENT` - environment to start the app in (default: development)
+* `BITCOIN_NETWORK` - bitcoin network to use (default: testnet), possible values: `mainnet`, `regtest` and `testnet`
 * `RUST_LOG` - the log level, e.g.: info, trace, debug, error (default: error)
 * `NOSTR_RELAY` - nostr relay endpoint (default: ws://localhost:8080)
 * `MINT_URL` - cashu mint endpoint (default: https://moksha.minibill.tech)

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,8 +25,8 @@ pub struct Config {
     pub surreal_db_connection: String,
     #[arg(default_value_t = false, long, env = "TERMINAL_CLIENT")]
     pub terminal_client: bool,
-    #[arg(default_value_t = String::from("development"),  env = "development")]
-    pub environment: String,
+    #[arg(default_value_t = String::from("bitcoin_network"),  env = "BITCOIN_NETWORK")]
+    pub bitcoin_network: String,
     #[arg(default_value_t = String::from("ws://localhost:8080"), long, env = "NOSTR_RELAY")]
     pub nostr_relay: String,
     #[arg(default_value_t = String::from("https://moksha.minibill.tech"), long, env = "MINT_URL")]
@@ -60,9 +60,10 @@ impl Config {
     }
 
     pub fn bitcoin_network(&self) -> Network {
-        match self.environment.as_str() {
-            "production" => Network::Bitcoin,
-            "development" => Network::Testnet,
+        match self.bitcoin_network.as_str() {
+            "mainnet" => Network::Bitcoin,
+            "testnet" => Network::Testnet,
+            "regtest" => Network::Regtest,
             _ => Network::Testnet,
         }
     }


### PR DESCRIPTION
## 📝 Description

This adds a specific config flag for setting the bitcoin network `BITCOIN_NETWORK`, which can be set to `mainnet`, `testnet` and `regtest` and defaults to Testnet as before.

For regtest to work properly, we'll need to add a few more things (e.g. currently we check blockstream for tx/address status)

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Set the flag to different values, start the app, check the logs to see the chosen network

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
