### PR TITLE
don't set payee to endorsee

### DIFF
--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -840,11 +840,7 @@ impl BillService {
             }
         };
 
-        let mut payee = bill_first_version.payee;
-
-        if let Some(ref endorsee) = last_endorsee {
-            payee = endorsee.clone();
-        }
+        let payee = bill_first_version.payee;
 
         let drawee_contact = self
             .extend_bill_chain_identity_data_from_contacts_or_identity(


### PR DESCRIPTION
## 📝 Description

Fix a bug where we set the payee to be the endorsee, if the endorsee is set, which is wrong.
The payee is always the payee of the first version bill. Who is the holder is checked separately (if endorsee is set, it's endorsee, otherwise it's the payee).

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Create a bill and endorse it to someone who isn't the payee
2. Make sure the payee returned is not the same as the endorsee
3. All other bill functionality should be the same

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
