### PR TITLE
add endpoint for all local bills regardless of selected identity

### DIFF
--- a/src/web/api_docs.rs
+++ b/src/web/api_docs.rs
@@ -14,6 +14,7 @@ use utoipa::OpenApi;
         handlers::notifications::websocket,
         handlers::notifications::sse,
         handlers::bill::list,
+        handlers::bill::all_bills_from_all_identities,
         handlers::bill::list_light,
         handlers::bill::search,
         handlers::bill::bill_detail,

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -219,6 +219,23 @@ pub async fn list(
     Ok(Json(BillsResponse { bills }))
 }
 
+#[utoipa::path(
+    tag = "All Bills from all identities",
+    path = "/bill/list_all",
+    description = "Get all local bills regardless of the selected identity",
+    responses(
+        (status = 200, description = "List of all local bills", body = BillsResponse<BitcreditBillToReturn>)
+    )
+)]
+#[get("/list_all")]
+pub async fn all_bills_from_all_identities(
+    _identity: IdentityCheck,
+    state: &State<ServiceContext>,
+) -> Result<Json<BillsResponse<BitcreditBillToReturn>>> {
+    let bills = state.bill_service.get_bills_from_all_identities().await?;
+    Ok(Json(BillsResponse { bills }))
+}
+
 #[get("/numbers_to_words_for_sum/<id>")]
 pub async fn numbers_to_words_for_sum(
     _identity: IdentityCheck,

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -127,6 +127,7 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
         .mount(
             "/bill",
             routes![
+                handlers::bill::all_bills_from_all_identities,
                 handlers::bill::issue_bill,
                 handlers::bill::bill_detail,
                 handlers::bill::list,


### PR DESCRIPTION
## 📝 Description

Adds an endpoints `bill/list_all`, which returns all bills from all local identities (personal and companies).

Relates to #373 

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Create bills with multiple local identities (personal and companies
2. Make sure that `bill/list` only returns the bills of the selected identities
3. Make sure `bill/list_all` returns all local bills

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #373 

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
