### PR TITLE
implement find and sync bill (blocks) from dht

### DIFF
--- a/src/dht/client.rs
+++ b/src/dht/client.rs
@@ -869,13 +869,17 @@ impl Client {
     pub async fn receive_updates_for_all_bills_topics(&mut self) -> Result<()> {
         let bill_ids = self.bill_store.get_ids().await?;
 
-        for bill in bill_ids {
-            let event =
-                GossipsubEvent::new(GossipsubEventId::CommandGetBillBlockchain, vec![0; 24]);
-            let message = event.to_byte_array()?;
-
-            self.add_message_to_bill_topic(message, &bill).await?;
+        for bill_id in bill_ids {
+            self.receive_updates_for_bill_topic(&bill_id).await?;
         }
+        Ok(())
+    }
+
+    pub async fn receive_updates_for_bill_topic(&mut self, bill_id: &str) -> Result<()> {
+        let event = GossipsubEvent::new(GossipsubEventId::CommandGetBillBlockchain, vec![0; 24]);
+        let message = event.to_byte_array()?;
+
+        self.add_message_to_bill_topic(message, bill_id).await?;
         Ok(())
     }
 

--- a/src/dht/event_loop.rs
+++ b/src/dht/event_loop.rs
@@ -342,6 +342,7 @@ impl EventLoop {
                                         if let Ok(mut local_chain) =
                                             self.bill_blockchain_store.get_chain(bill_id).await
                                         {
+                                            info!("Received blockchain for bill: {bill_id} from peer: {node_id}, local block height: {}, remote block height: {}", local_chain.block_height(), remote_chain.block_height());
                                             let blocks_to_add = local_chain
                                                 .get_blocks_to_add_from_other_chain(&remote_chain);
                                             for block in blocks_to_add {

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -249,15 +249,14 @@ pub async fn numbers_to_words_for_sum(
 }
 
 #[get("/dht/<bill_id>")]
-pub async fn find_bill_in_dht(
+pub async fn find_and_sync_with_bill_in_dht(
     _identity: IdentityCheck,
     state: &State<ServiceContext>,
     bill_id: &str,
 ) -> Result<Status> {
-    let (caller_public_data, caller_keys) = get_signer_public_data_and_keys(state).await?;
     state
         .bill_service
-        .find_bill_in_dht(bill_id, &caller_public_data, &caller_keys)
+        .find_and_sync_with_bill_in_dht(bill_id)
         .await?;
     Ok(Status::Ok)
 }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -145,7 +145,7 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
                 handlers::bill::check_payment,
                 handlers::bill::bitcoin_key,
                 handlers::bill::numbers_to_words_for_sum,
-                handlers::bill::find_bill_in_dht,
+                handlers::bill::find_and_sync_with_bill_in_dht,
                 handlers::bill::check_dht_for_bills,
                 handlers::bill::holder,
                 handlers::bill::search,


### PR DESCRIPTION
## 📝 Description

Changes the `/bill/dht/<id>` endpoint to trigger a gossipsub request to receive the latest blockchain. It then syncs the chain according to our merging logic (longest wins).

This should help to remediate connectivity issues, which lead to clients having different blockchain states.
The endpoint is fast and asynchronous and fails only, if the bill doesn't exist.
This can be used on the frontend to make sure the state of local bills is always up2date without restarting.

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Create a bill with 2 clients
2. Do a few actions, like req to accept/accept etc.
3. On one client, delete one or several blocks from surrealdb
4. On this client, call `/bill/dht/<bill_id>`
5. It should now be synced with the chain from the other client

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
