### PR TITLE
implement bill endorsements endpoint,fix cors,add endorsement count

### DIFF
--- a/src/blockchain/bill/block.rs
+++ b/src/blockchain/bill/block.rs
@@ -984,7 +984,7 @@ impl BillBlock {
         }
     }
 
-    /// If the block is a non-recourse, holder-changing block (issue, endorse, sell, mint), returns
+    /// If the block is holder-changing block (issue, endorse, sell, mint, recourse), returns
     /// the new holder and signer data from the block
     pub fn get_holder_from_block(&self, bill_keys: &BillKeys) -> Result<Option<HolderFromBlock>> {
         match self.op_code {
@@ -1017,6 +1017,14 @@ impl BillBlock {
                 Ok(Some(HolderFromBlock {
                     holder: block.buyer,
                     signer: block.seller,
+                    signatory: block.signatory,
+                }))
+            }
+            Recourse => {
+                let block: BillRecourseBlockData = self.get_decrypted_block_bytes(bill_keys)?;
+                Ok(Some(HolderFromBlock {
+                    holder: block.recoursee,
+                    signer: block.recourser,
                     signatory: block.signatory,
                 }))
             }

--- a/src/blockchain/bill/chain.rs
+++ b/src/blockchain/bill/chain.rs
@@ -89,6 +89,22 @@ impl BillBlockchain {
         })
     }
 
+    /// Counts the number of endorsement blocks (mint, sell, endorse, recourse)
+    pub fn get_endorsements_count(&self) -> u64 {
+        self.blocks
+            .iter()
+            .filter(|block| {
+                matches!(
+                    block.op_code,
+                    BillOpCode::Mint
+                        | BillOpCode::Sell
+                        | BillOpCode::Endorse
+                        | BillOpCode::Recourse
+                )
+            })
+            .count() as u64
+    }
+
     /// Checks if the the chain has Endorse, or Sell blocks in it
     pub fn has_been_endorsed_or_sold(&self) -> bool {
         self.blocks

--- a/src/service/contact_service.rs
+++ b/src/service/contact_service.rs
@@ -412,6 +412,34 @@ impl From<BillIdentityBlockData> for LightIdentityPublicData {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct LightIdentityPublicDataWithAddress {
+    pub name: String,
+    pub node_id: String,
+    #[serde(flatten)]
+    pub postal_address: PostalAddress,
+}
+
+impl From<IdentityPublicData> for LightIdentityPublicDataWithAddress {
+    fn from(value: IdentityPublicData) -> Self {
+        Self {
+            name: value.name,
+            node_id: value.node_id,
+            postal_address: value.postal_address,
+        }
+    }
+}
+
+impl From<BillIdentityBlockData> for LightIdentityPublicDataWithAddress {
+    fn from(value: BillIdentityBlockData) -> Self {
+        Self {
+            name: value.name,
+            node_id: value.node_id,
+            postal_address: value.postal_address,
+        }
+    }
+}
+
 impl From<Contact> for IdentityPublicData {
     fn from(value: Contact) -> Self {
         Self {

--- a/src/web/api_docs.rs
+++ b/src/web/api_docs.rs
@@ -18,6 +18,8 @@ use utoipa::OpenApi;
         handlers::bill::list_light,
         handlers::bill::search,
         handlers::bill::bill_detail,
+        handlers::bill::get_past_endorsees_for_bill,
+        handlers::bill::get_endorsements_for_bill,
         handlers::identity::return_identity,
         handlers::identity::create_identity,
         handlers::identity::change_identity,

--- a/src/web/data.rs
+++ b/src/web/data.rs
@@ -1,3 +1,4 @@
+use crate::service::contact_service::LightIdentityPublicDataWithAddress;
 use crate::service::identity_service::IdentityType;
 use crate::service::{
     bill_service::LightBitcreditBillToReturn,
@@ -13,6 +14,19 @@ use std::fmt;
 use utoipa::ToSchema;
 
 #[derive(Debug, Serialize, ToSchema)]
+pub struct EndorsementsResponse {
+    pub endorsements: Vec<Endorsement>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct Endorsement {
+    pub pay_to_the_order_of: LightIdentityPublicDataWithAddress,
+    pub signed: LightSignedBy,
+    pub signing_timestamp: u64,
+    pub signing_address: PostalAddress,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PastEndorseesResponse {
     pub past_endorsees: Vec<PastEndorsee>,
 }
@@ -22,6 +36,7 @@ pub struct PastEndorsee {
     pub pay_to_the_order_of: LightIdentityPublicData,
     pub signed: LightSignedBy,
     pub signing_timestamp: u64,
+    pub signing_address: PostalAddress,
 }
 
 #[derive(Debug, Serialize, ToSchema)]

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -9,9 +9,9 @@ use crate::util::{self, base58_encode, BcrKeys};
 use crate::web::data::{
     AcceptBitcreditBillPayload, AcceptMintBitcreditBillPayload, BillCombinedBitcoinKey, BillId,
     BillNumbersToWordsForSum, BillType, BillsResponse, BillsSearchFilterPayload,
-    BitcreditBillPayload, EndorseBitcreditBillPayload, MintBitcreditBillPayload,
-    OfferToSellBitcreditBillPayload, PastEndorseesResponse, RejectActionBillPayload,
-    RequestRecourseForAcceptancePayload, RequestRecourseForPaymentPayload,
+    BitcreditBillPayload, EndorseBitcreditBillPayload, EndorsementsResponse,
+    MintBitcreditBillPayload, OfferToSellBitcreditBillPayload, PastEndorseesResponse,
+    RejectActionBillPayload, RequestRecourseForAcceptancePayload, RequestRecourseForPaymentPayload,
     RequestToAcceptBitcreditBillPayload, RequestToMintBitcreditBillPayload,
     RequestToPayBitcreditBillPayload, UploadBillFilesForm, UploadFilesResponse,
 };
@@ -68,6 +68,37 @@ pub async fn get_signer_public_data_and_keys(
     Ok((signer_public_data, signer_keys))
 }
 
+#[utoipa::path(
+    tag = "Endorsements",
+    path = "/bill/endorsements/{id}",
+    description = "Get endorsements of the given bill",
+    responses(
+        (status = 200, description = "Endorsements", body = EndorsementsResponse)
+    )
+)]
+#[get("/endorsements/<id>")]
+pub async fn get_endorsements_for_bill(
+    _identity: IdentityCheck,
+    state: &State<ServiceContext>,
+    id: &str,
+) -> Result<Json<EndorsementsResponse>> {
+    let result = state
+        .bill_service
+        .get_endorsements(id, &get_current_identity_node_id(state).await)
+        .await?;
+    Ok(Json(EndorsementsResponse {
+        endorsements: result,
+    }))
+}
+
+#[utoipa::path(
+    tag = "Past Endorsees",
+    path = "/bill/past_endorsees/{id}",
+    description = "Get all past endorsees of the given bill",
+    responses(
+        (status = 200, description = "Past Endorsees", body = PastEndorseesResponse)
+    )
+)]
 #[get("/past_endorsees/<id>")]
 pub async fn get_past_endorsees_for_bill(
     _identity: IdentityCheck,


### PR DESCRIPTION
## 📝 Description

* Fix CORS (OPTION routes returning 404 always)
* Add `endorsement_count` to bill detail, to save a request on frontend
* Add endpoint `/bill/endorsement/<id>` that returns all endorsements in the bill

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Check OPTIONS requests, make sure they return 200
2. Check other requests, make sure they still work
3. Make sure the `endorsement_count` on the bill is correct
4. Call `/bill/endorsements/<bill_id>` and check that all endorsements are there

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
