### PR TITLE
add catch all for frontend and /api for be

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
     <script>
         async function fetchIdentity() {
             try {
-                const response = await fetch('/identity/detail'); 
+                const response = await fetch('/api/identity/detail');
                 if (!response.ok) {
                     let resp = await response.json();
                     throw new Error(`${response.status} - ${resp.error}/${resp.message}`);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,5 +31,6 @@
         }
         fetchIdentity();
     </script>
+    <script src="./main.js"></script>
 </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/src/web/handlers/mod.rs
+++ b/src/web/handlers/mod.rs
@@ -5,9 +5,11 @@ use super::data::{
 use crate::{
     constants::VALID_CURRENCIES,
     service::{Error, Result, ServiceContext},
+    CONFIG,
 };
 use bill::get_current_identity_node_id;
-use rocket::{get, post, serde::json::Json, Shutdown, State};
+use rocket::{fs::NamedFile, get, post, serde::json::Json, Shutdown, State};
+use std::path::Path;
 
 pub mod bill;
 pub mod company;
@@ -16,6 +18,13 @@ pub mod identity;
 pub mod middleware;
 pub mod notifications;
 pub mod quotes;
+
+#[get("/<_..>", rank = 10)]
+pub async fn serve_frontend() -> Option<NamedFile> {
+    NamedFile::open(Path::new(&CONFIG.frontend_serve_folder).join("index.html"))
+        .await
+        .ok()
+}
 
 #[get("/")]
 pub async fn exit(shutdown: Shutdown, state: &State<ServiceContext>) {

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -1,7 +1,6 @@
 use crate::service::ServiceContext;
 use api_docs::ApiDocs;
 use log::info;
-use rocket::fs::FileServer;
 use rocket::http::{Method, Status};
 use rocket::{catch, catchers, routes, Build, Config, Request, Rocket};
 use rocket_cors::{AllowedHeaders, AllowedOrigins, CorsOptions};
@@ -75,16 +74,16 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
 
     let rocket = rocket::custom(config)
         .attach(cors.clone())
-        .mount("/", rocket_cors::catch_all_options_routes())
+        .mount("/api/", rocket_cors::catch_all_options_routes())
         .register("/", catchers![default_catcher, not_found])
         .manage(context)
         .manage(cors)
-        .mount("/exit", routes![handlers::exit])
-        .mount("/currencies", routes![handlers::currencies])
-        .mount("/overview", routes![handlers::overview])
-        .mount("/search", routes![handlers::search])
+        .mount("/api/exit", routes![handlers::exit])
+        .mount("/api/currencies", routes![handlers::currencies])
+        .mount("/api/overview", routes![handlers::overview])
+        .mount("/api/search", routes![handlers::search])
         .mount(
-            "/identity",
+            "/api/identity",
             routes![
                 handlers::identity::create_identity,
                 handlers::identity::change_identity,
@@ -100,11 +99,7 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             ],
         )
         .mount(
-            &CONFIG.frontend_url_path,
-            FileServer::from(&CONFIG.frontend_serve_folder),
-        )
-        .mount(
-            "/contacts",
+            "/api/contacts",
             routes![
                 handlers::contacts::new_contact,
                 handlers::contacts::edit_contact,
@@ -116,7 +111,7 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             ],
         )
         .mount(
-            "/company",
+            "/api/company",
             routes![
                 handlers::company::check_companies_in_dht,
                 handlers::company::list,
@@ -131,7 +126,7 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             ],
         )
         .mount(
-            "/bill",
+            "/api/bill",
             routes![
                 handlers::bill::all_bills_from_all_identities,
                 handlers::bill::issue_bill,
@@ -166,14 +161,14 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             ],
         )
         .mount(
-            "/quote",
+            "/api/quote",
             routes![
                 handlers::quotes::return_quote,
                 handlers::quotes::accept_quote
             ],
         )
         .mount(
-            "/",
+            "/api/",
             routes![
                 handlers::notifications::list_notifications,
                 handlers::notifications::mark_notification_done,
@@ -183,9 +178,10 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             ],
         )
         .mount(
-            "/",
+            "/api/",
             SwaggerUi::new("/swagger-ui/<_..>").url("/api-docs/openapi.json", ApiDocs::openapi()),
-        );
+        )
+        .mount(&CONFIG.frontend_url_path, routes![handlers::serve_frontend]);
 
     info!("HTTP Server Listening on {}", conf.http_listen_url());
 

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -16,6 +16,7 @@ use crate::constants::MAX_FILE_SIZE_BYTES;
 use crate::CONFIG;
 use rocket::data::ByteUnit;
 use rocket::figment::Figment;
+use rocket::fs::FileServer;
 use rocket::serde::json::Json;
 use serde_json::json;
 
@@ -181,6 +182,11 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             "/api/",
             SwaggerUi::new("/swagger-ui/<_..>").url("/api-docs/openapi.json", ApiDocs::openapi()),
         )
+        .mount(
+            &CONFIG.frontend_url_path,
+            FileServer::from(&CONFIG.frontend_serve_folder).rank(5),
+        )
+        // TODO: fall back to index, but serve static files first
         .mount(&CONFIG.frontend_url_path, routes![handlers::serve_frontend]);
 
     info!("HTTP Server Listening on {}", conf.http_listen_url());


### PR DESCRIPTION
## 📝 Description

* Redirects all routes to frontend index.html except for our routes, which are now behind /api/*

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. All routes go to frontend except for /api, BE is now at /api

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
