### PR TITLE
Notification filter

### DIFF
--- a/src/persistence/notification.rs
+++ b/src/persistence/notification.rs
@@ -11,7 +11,7 @@ pub trait NotificationStoreApi: Send + Sync {
     /// Stores a new notification into the database
     async fn add(&self, notification: Notification) -> Result<Notification>;
     /// Returns all currently active notifications from the database
-    async fn list(&self) -> Result<Vec<Notification>>;
+    async fn list(&self, active: Option<bool>) -> Result<Vec<Notification>>;
     /// Returns the latest active notification for the given reference and notification type
     async fn get_latest_by_reference(
         &self,

--- a/src/persistence/notification.rs
+++ b/src/persistence/notification.rs
@@ -11,7 +11,7 @@ pub trait NotificationStoreApi: Send + Sync {
     /// Stores a new notification into the database
     async fn add(&self, notification: Notification) -> Result<Notification>;
     /// Returns all currently active notifications from the database
-    async fn list(&self, active: Option<bool>) -> Result<Vec<Notification>>;
+    async fn list(&self, filter: NotificationFilter) -> Result<Vec<Notification>>;
     /// Returns the latest active notification for the given reference and notification type
     async fn get_latest_by_reference(
         &self,
@@ -40,4 +40,89 @@ pub trait NotificationStoreApi: Send + Sync {
         block_height: i32,
         action_type: ActionType,
     ) -> Result<bool>;
+}
+
+#[derive(Default, Clone, PartialEq, Debug)]
+pub struct NotificationFilter {
+    pub active: Option<bool>,
+    pub reference_id: Option<String>,
+    pub notification_type: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+impl NotificationFilter {
+    pub fn filters(&self) -> String {
+        let mut parts = vec![];
+        if self.active.is_some() {
+            parts.push("active = $active");
+        }
+        if self.reference_id.is_some() {
+            parts.push("reference_id = $reference_id");
+        }
+        if self.notification_type.is_some() {
+            parts.push("notification_type = $notification_type");
+        }
+
+        let filters = parts.join(" AND ");
+        if filters.is_empty() {
+            filters
+        } else {
+            format!("WHERE {}", filters)
+        }
+    }
+
+    pub fn get_limit(&self) -> i64 {
+        self.limit.unwrap_or(200)
+    }
+
+    pub fn get_offset(&self) -> i64 {
+        self.offset.unwrap_or(0)
+    }
+
+    pub fn get_active(&self) -> Option<(String, bool)> {
+        self.active.map(|active| ("active".to_string(), active))
+    }
+
+    pub fn get_reference_id(&self) -> Option<(String, String)> {
+        self.reference_id
+            .as_ref()
+            .map(|reference_id| ("reference_id".to_string(), reference_id.to_string()))
+    }
+
+    pub fn get_notification_type(&self) -> Option<(String, String)> {
+        self.notification_type.as_ref().map(|notification_type| {
+            (
+                "notification_type".to_string(),
+                notification_type.to_string(),
+            )
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_query_filters() {
+        let empty = super::NotificationFilter::default();
+        assert_eq!(empty.filters(), "");
+
+        let active = super::NotificationFilter {
+            active: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(active.filters(), "WHERE active = $active");
+
+        let all = super::NotificationFilter {
+            active: Some(true),
+            reference_id: Some("123".to_string()),
+            notification_type: Some("Bill".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            all.filters(),
+            "WHERE active = $active AND reference_id = $reference_id AND notification_type = $notification_type"
+        );
+    }
 }

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -42,6 +42,8 @@ use async_trait::async_trait;
 use borsh::to_vec;
 use borsh_derive::{BorshDeserialize, BorshSerialize};
 use log::info;
+#[cfg(test)]
+use mockall::automock;
 use rocket::http::ContentType;
 use rocket::Response;
 use rocket::{http::Status, response::Responder};
@@ -259,6 +261,7 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for Error {
     }
 }
 
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait BillServiceApi: Send + Sync {
     /// Get bill balances

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -227,7 +227,7 @@ pub async fn create_service_context(
     let notification_service =
         create_notification_service(nostr_client.clone(), db.notification_store.clone()).await?;
 
-    let bill_service = BillService::new(
+    let bill_service = Arc::new(BillService::new(
         client.clone(),
         db.bill_store,
         db.bill_blockchain_store.clone(),
@@ -239,7 +239,7 @@ pub async fn create_service_context(
         db.company_chain_store.clone(),
         db.contact_store.clone(),
         db.company_store.clone(),
-    );
+    ));
     let identity_service = IdentityService::new(
         db.identity_store.clone(),
         db.file_upload_store.clone(),
@@ -264,11 +264,12 @@ pub async fn create_service_context(
         db.nostr_event_offset_store.clone(),
         db.notification_store.clone(),
         push_service.clone(),
+        bill_service.clone(),
     )
     .await?;
 
     let search_service = SearchService::new(
-        Arc::new(bill_service.clone()),
+        bill_service.clone(),
         contact_service.clone(),
         Arc::new(company_service.clone()),
     );
@@ -285,7 +286,7 @@ pub async fn create_service_context(
         dht_client: client,
         contact_service,
         search_service: Arc::new(search_service),
-        bill_service: Arc::new(bill_service),
+        bill_service,
         identity_service: Arc::new(identity_service),
         company_service: Arc::new(company_service),
         file_upload_service: Arc::new(file_upload_service),

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -264,7 +264,6 @@ pub async fn create_service_context(
         db.nostr_event_offset_store.clone(),
         db.notification_store.clone(),
         push_service.clone(),
-        bill_service.clone(),
     )
     .await?;
 

--- a/src/service/notification_service/bill_action_event_handler.rs
+++ b/src/service/notification_service/bill_action_event_handler.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 
 use crate::{
     persistence::notification::NotificationStoreApi,
-    service::notification_service::event::{BillActionEventPayload, Event},
+    service::{
+        bill_service::BillServiceApi,
+        notification_service::event::{BillActionEventPayload, Event},
+    },
 };
 
 use super::{
@@ -15,16 +18,19 @@ use async_trait::async_trait;
 #[derive(Clone)]
 pub struct BillActionEventHandler {
     notification_store: Arc<dyn NotificationStoreApi>,
+    bill_service: Arc<dyn BillServiceApi>,
     push_service: Arc<dyn PushApi>,
 }
 
 impl BillActionEventHandler {
     pub fn new(
         notification_store: Arc<dyn NotificationStoreApi>,
+        bill_service: Arc<dyn BillServiceApi>,
         push_service: Arc<dyn PushApi>,
     ) -> Self {
         Self {
             notification_store,
+            bill_service,
             push_service,
         }
     }
@@ -65,9 +71,13 @@ impl NotificationHandlerApi for BillActionEventHandler {
     async fn handle_event(&self, event: EventEnvelope) -> Result<()> {
         let event: Option<Event<BillActionEventPayload>> = event.try_into().ok();
         if let Some(event) = event {
+            // Lookup the bill
+            let _bill = self.bill_service.get_bill(&event.data.bill_id).await;
+
             // create notification
             let notification = Notification::new_bill_notification(
                 &event.data.bill_id,
+                "the identity this notification is for",
                 &self.event_description(&event.event_type),
                 Some(serde_json::to_value(&event.data)?),
             );

--- a/src/service/notification_service/bill_action_event_handler.rs
+++ b/src/service/notification_service/bill_action_event_handler.rs
@@ -62,13 +62,13 @@ impl NotificationHandlerApi for BillActionEventHandler {
         true
     }
 
-    async fn handle_event(&self, event: EventEnvelope, identity: &str) -> Result<()> {
+    async fn handle_event(&self, event: EventEnvelope, node_id: &str) -> Result<()> {
         let event: Option<Event<BillActionEventPayload>> = event.try_into().ok();
         if let Some(event) = event {
             // create notification
             let notification = Notification::new_bill_notification(
                 &event.data.bill_id,
-                identity,
+                node_id,
                 &self.event_description(&event.event_type),
                 Some(serde_json::to_value(&event.data)?),
             );

--- a/src/service/notification_service/default_service.rs
+++ b/src/service/notification_service/default_service.rs
@@ -346,7 +346,6 @@ mod tests {
 
     use crate::persistence::nostr::MockNostrEventOffsetStoreApi;
     use crate::persistence::notification::MockNotificationStoreApi;
-    use crate::service::bill_service::MockBillServiceApi;
     use crate::service::contact_service::MockContactServiceApi;
     use crate::service::notification_service::create_nostr_consumer;
     use crate::service::notification_service::push_notification::MockPushApi;
@@ -863,14 +862,12 @@ mod tests {
         let store = Arc::new(MockNostrEventOffsetStoreApi::new());
         let notification_store = Arc::new(MockNotificationStoreApi::new());
         let push_service = Arc::new(MockPushApi::new());
-        let bill_service = Arc::new(MockBillServiceApi::new());
         let _ = create_nostr_consumer(
             client,
             contact_service,
             store,
             notification_store,
             push_service,
-            bill_service,
         )
         .await;
     }

--- a/src/service/notification_service/handler.rs
+++ b/src/service/notification_service/handler.rs
@@ -17,7 +17,7 @@ pub trait NotificationHandlerApi: Send + Sync {
     /// should be able to deserialize the data into its T type because the EventType
     /// determines the T type. Identity represents the active identity that is receiving
     /// the event.
-    async fn handle_event(&self, event: EventEnvelope, identity: &str) -> Result<()>;
+    async fn handle_event(&self, event: EventEnvelope, node_id: &str) -> Result<()>;
 }
 
 /// Logs all events that are received and registered in the event_types.

--- a/src/service/notification_service/handler.rs
+++ b/src/service/notification_service/handler.rs
@@ -15,8 +15,9 @@ pub trait NotificationHandlerApi: Send + Sync {
     /// Handle the event. This is called by the notification processor which should
     /// have checked the event type before calling this method. The actual implementation
     /// should be able to deserialize the data into its T type because the EventType
-    /// determines the T type.
-    async fn handle_event(&self, event: EventEnvelope) -> Result<()>;
+    /// determines the T type. Identity represents the active identity that is receiving
+    /// the event.
+    async fn handle_event(&self, event: EventEnvelope, identity: &str) -> Result<()>;
 }
 
 /// Logs all events that are received and registered in the event_types.
@@ -31,9 +32,9 @@ impl NotificationHandlerApi for LoggingEventHandler {
         self.event_types.contains(event_type)
     }
 
-    async fn handle_event(&self, event: EventEnvelope) -> Result<()> {
+    async fn handle_event(&self, event: EventEnvelope, identity: &str) -> Result<()> {
         info!("########### EVENT RECEIVED #############");
-        info!("Received event: {event:?}");
+        info!("Received event: {event:?} for identity: {identity}");
         info!("########################################");
         Ok(())
     }
@@ -61,7 +62,7 @@ mod tests {
 
         // handler should run successfully
         event_handler
-            .handle_event(envelope)
+            .handle_event(envelope, "identity")
             .await
             .expect("event was not handled");
 

--- a/src/service/notification_service/mod.rs
+++ b/src/service/notification_service/mod.rs
@@ -39,7 +39,6 @@ pub use transport::NotificationJsonTransportApi;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::bill_service::BillServiceApi;
 use super::contact_service::ContactServiceApi;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -118,7 +117,6 @@ pub async fn create_nostr_consumer(
     nostr_event_offset_store: Arc<dyn NostrEventOffsetStoreApi>,
     notification_store: Arc<dyn NotificationStoreApi>,
     push_service: Arc<dyn PushApi>,
-    bill_service: Arc<dyn BillServiceApi>,
 ) -> Result<NostrConsumer> {
     // register the logging event handler for all events for now. Later we will probably
     // setup the handlers outside and pass them to the consumer via this functions arguments.
@@ -128,7 +126,6 @@ pub async fn create_nostr_consumer(
         }),
         Box::new(BillActionEventHandler::new(
             notification_store,
-            bill_service,
             push_service,
         )),
     ];

--- a/src/service/notification_service/mod.rs
+++ b/src/service/notification_service/mod.rs
@@ -1,6 +1,7 @@
+use std::fmt::Display;
 use std::sync::Arc;
 
-use crate::persistence::notification::NotificationStoreApi;
+use crate::persistence::notification::{NotificationFilter, NotificationStoreApi};
 use crate::persistence::NostrEventOffsetStoreApi;
 use crate::persistence::{self, identity::IdentityStoreApi};
 use crate::service::contact_service::IdentityPublicData;
@@ -242,8 +243,11 @@ pub trait NotificationServiceApi: Send + Sync {
     /// Receiver: Mint (new holder), Action: CheckBill
     async fn send_quote_is_approved_event(&self, quote: &BitcreditBill) -> Result<()>;
 
-    /// Returns active client notifications
-    async fn get_client_notifications(&self, active: Option<bool>) -> Result<Vec<Notification>>;
+    /// Returns filtered client notifications
+    async fn get_client_notifications(
+        &self,
+        filter: NotificationFilter,
+    ) -> Result<Vec<Notification>>;
 
     /// Marks the notification with given id as done
     async fn mark_notification_as_done(&self, notification_id: &str) -> Result<()>;
@@ -321,4 +325,10 @@ impl Notification {
 pub enum NotificationType {
     General,
     Bill,
+}
+
+impl Display for NotificationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(format!("{:?}", self).as_str())
+    }
 }

--- a/src/service/notification_service/test_utils.rs
+++ b/src/service/notification_service/test_utils.rs
@@ -67,7 +67,7 @@ impl NotificationHandlerApi for TestEventHandler<TestEventPayload> {
         }
     }
 
-    async fn handle_event(&self, event: EventEnvelope) -> Result<()> {
+    async fn handle_event(&self, event: EventEnvelope, _: &str) -> Result<()> {
         *self.called.lock().await = true;
         let event: Event<TestEventPayload> = event.try_into()?;
         *self.received_event.lock().await = Some(event);

--- a/src/web/handlers/notifications.rs
+++ b/src/web/handlers/notifications.rs
@@ -12,13 +12,19 @@ use serde_json::Value;
     description = "Get all active notifications",
     responses(
         (status = 200, description = "List of notifications", body = Vec<Notification>)
+    ),
+    params(
+        ("active" = bool, description = "Returns only active notifications when true, inactive when false and all when left out")
     )
 )]
-#[get("/notifications")]
-pub async fn list_notifications(state: &State<ServiceContext>) -> Result<Json<Vec<Notification>>> {
+#[get("/notifications?<active>")]
+pub async fn list_notifications(
+    state: &State<ServiceContext>,
+    active: Option<bool>,
+) -> Result<Json<Vec<Notification>>> {
     let notifications: Vec<Notification> = state
         .notification_service
-        .get_client_notifications()
+        .get_client_notifications(active)
         .await?;
     Ok(Json(notifications))
 }

--- a/src/web/handlers/notifications.rs
+++ b/src/web/handlers/notifications.rs
@@ -15,11 +15,11 @@ use serde_json::Value;
         (status = 200, description = "List of notifications", body = Vec<Notification>)
     ),
     params(
-        ("active" = bool, Query, description = "Returns only active notifications when true, inactive when false and all when left out"),
-        ("reference_id" = String, Query, description = "The id of the entity to filter by (eg. a bill id)"),
-        ("notification_type" = String, Query, description = "The type of notifications to return (eg. Bill)"),
-        ("limit" = i64, Query, description = "The max number of notifications to return"),
-        ("offset" = i64, Query, description = "The number of notifications to skip at the start of the result")
+        ("active" = Option<bool>, Query, description = "Returns only active notifications when true, inactive when false and all when left out"),
+        ("reference_id" = Option<String>, Query, description = "The id of the entity to filter by (eg. a bill id)"),
+        ("notification_type" = Option<String>, Query, description = "The type of notifications to return (eg. Bill)"),
+        ("limit" = Option<i64>, Query, description = "The max number of notifications to return"),
+        ("offset" = Option<i64>, Query, description = "The number of notifications to skip at the start of the result")
     )
 )]
 #[get("/notifications?<active>&<reference_id>&<notification_type>&<limit>&<offset>")]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -179,8 +179,9 @@ pub fn rocket_main(context: ServiceContext) -> Rocket<Build> {
             ],
         )
         .mount(
-            "/api/",
-            SwaggerUi::new("/swagger-ui/<_..>").url("/api-docs/openapi.json", ApiDocs::openapi()),
+            "/",
+            SwaggerUi::new("/api/swagger-ui/<_..>")
+                .url("/api/api-docs/openapi.json", ApiDocs::openapi()),
         )
         .mount(
             &CONFIG.frontend_url_path,


### PR DESCRIPTION
## 📝 Description

As discussed yesterday this adds an identity to the notifications and some filters to the list endpoint. With current state we are not able to address Companies with direct private messages which means they will not be able to receive push notifications. We can switch the Nostr identity when the system identity is switched which would allow receiving push for Companies but this is a bigger change and a bad idea to add so close before presentation. It also requires companies to expose npub and relay in the contact later.

Relates to #(issue-number)

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).
