### PR TITLE
small perf improvements and mempool link

### DIFF
--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -26,6 +26,10 @@ pub enum Error {
     #[error("Blockchain is invalid")]
     BlockchainInvalid,
 
+    /// If there is an error deserializing and decrypting blocks
+    #[error("Could not parse and decrypt blockchain")]
+    BlockchainParse,
+
     /// If certain block is not valid and can't be added
     #[error("Block is invalid")]
     BlockInvalid,

--- a/src/external/bitcoin.rs
+++ b/src/external/bitcoin.rs
@@ -56,6 +56,8 @@ pub trait BitcoinClientApi: Send + Sync {
         pkey: &bitcoin::PrivateKey,
         pkey_to_combine: &bitcoin::PrivateKey,
     ) -> Result<String>;
+
+    fn get_mempool_link_for_address(&self, address: &str) -> String;
 }
 
 #[derive(Clone)]
@@ -73,6 +75,17 @@ impl BitcoinClient {
             }
             _ => {
                 format!("https://blockstream.info/testnet/api{path}")
+            }
+        }
+    }
+
+    pub fn link_url(&self, path: &str) -> String {
+        match CONFIG.bitcoin_network() {
+            Network::Bitcoin => {
+                format!("https://blockstream.info{path}")
+            }
+            _ => {
+                format!("https://blockstream.info/testnet{path}")
             }
         }
     }
@@ -168,6 +181,10 @@ impl BitcoinClientApi for BitcoinClient {
             .add_tweak(&Scalar::from(pkey_to_combine.inner))
             .map_err(Error::from)?;
         Ok(bitcoin::PrivateKey::new(private_key_bill, CONFIG.bitcoin_network()).to_string())
+    }
+
+    fn get_mempool_link_for_address(&self, address: &str) -> String {
+        self.link_url(&format!("/address/{address}"))
     }
 }
 

--- a/src/external/time.rs
+++ b/src/external/time.rs
@@ -10,7 +10,7 @@ pub struct TimeApi {
 
 impl TimeApi {
     pub async fn get_atomic_time() -> Self {
-        match reqwest::get("https://api.timezonedb.com/v2.1/get-time-zone?key=RQ6ZFDOXPVLR&format=json&by=zone&zone=Europe/Vienna")
+        match reqwest::get("https://vip.timezonedb.com/v2.1/get-time-zone?key=AY3Q7V1JPPNX&format=json&fields=timestamp&by=zone&zone=UTC")
             .await
             {
                 Err(e) => {

--- a/src/persistence/db/notification.rs
+++ b/src/persistence/db/notification.rs
@@ -314,8 +314,10 @@ mod tests {
             .await
             .expect("could not create notification");
 
-        let mut filter = NotificationFilter::default();
-        filter.active = Some(true);
+        let filter = NotificationFilter {
+            active: Some(true),
+            ..Default::default()
+        };
         let all = store
             .list(filter.clone())
             .await

--- a/src/service/contact_service.rs
+++ b/src/service/contact_service.rs
@@ -63,6 +63,7 @@ pub trait ContactServiceApi: Send + Sync {
     ) -> Result<Contact>;
 
     /// Returns whether a given npub (as hex) is in our contact list.
+    #[allow(dead_code)]
     async fn is_known_npub(&self, npub: &str) -> Result<bool>;
 
     /// opens and decrypts the attached file from the given contact

--- a/src/service/notification_service/default_service.rs
+++ b/src/service/notification_service/default_service.rs
@@ -782,8 +782,10 @@ mod tests {
         let mut mock_store = MockNotificationStoreApi::new();
         let result = Notification::new_bill_notification("bill_id", "node_id", "desc", None);
         let returning = result.clone();
-        let mut filter = NotificationFilter::default();
-        filter.active = Some(true);
+        let filter = NotificationFilter {
+            active: Some(true),
+            ..Default::default()
+        };
         mock_store
             .expect_list()
             .with(eq(filter.clone()))

--- a/src/web/handlers/bill.rs
+++ b/src/web/handlers/bill.rs
@@ -310,7 +310,7 @@ pub async fn bill_detail(
     state: &State<ServiceContext>,
     id: &str,
 ) -> Result<Json<BitcreditBillToReturn>> {
-    let current_timestamp = external::time::TimeApi::get_atomic_time().await.timestamp;
+    let current_timestamp = util::date::now().timestamp() as u64;
     let identity = state.identity_service.get_identity().await?;
     let bill_detail = state
         .bill_service


### PR DESCRIPTION
## 📝 Description

These are some small and safe changes to improve the performance of fetching bills before we move to a caching solution.

Local rough measurements:
Bill Detail, before: ~500 ms, after: ~70ms
Bill List endpoints (Light, Full, All, Balance, Search) with ~10 full bills: before: ~900 ms, after: ~250 ms

So the change should be noticeable in the UI.

* Switch external time API to premium, only use needed fields and use UTC (bugfix)
* Use local UTC for fetching requests
* Fetch bills in parallel and move computation intensive (deserialization and decryption) tasks to a blocking thread pool, because otherwise the task queue is blocked and the parallelization doesn't help
* Some small linting fixes
* Add mempool link for address to pay

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Just do bills requests - they should be noticeably faster, with the same functionality as before

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
