### PR TITLE
reject to accept does not need req to accept

### DIFF
--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -1560,16 +1560,6 @@ impl BillService {
                 if blockchain.block_with_operation_code_exists(BillOpCode::Accept) {
                     return Err(Error::BillAlreadyAccepted);
                 }
-                // there has to be a request to accept block that is not expired
-                if let Some(req_to_accept) =
-                    blockchain.get_last_version_block_with_op_code(BillOpCode::RequestToAccept)
-                {
-                    if req_to_accept.timestamp + ACCEPT_DEADLINE_SECONDS < timestamp {
-                        return Err(Error::RequestAlreadyExpired);
-                    }
-                } else {
-                    return Err(Error::BillWasNotRequestedToAccept);
-                }
             }
             BillOpCode::RejectToBuy => {
                 if let RecourseWaitingForPayment::Yes(_) = waiting_for_recourse {


### PR DESCRIPTION
## 📝 Description

Removes validation rule that reject to accept needs a request to accept block. Bills can be rejected to accept outright.

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

See above

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. In a bill without a request to accept block, try to reject to accept - it should work

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
