### PR TITLE
remove identity check from identity file upload

### DIFF
--- a/src/web/handlers/identity.rs
+++ b/src/web/handlers/identity.rs
@@ -47,7 +47,6 @@ pub async fn get_file(
 
 #[post("/upload_file", data = "<file_upload_form>")]
 pub async fn upload_file(
-    _identity: IdentityCheck,
     state: &State<ServiceContext>,
     file_upload_form: Form<UploadFileForm<'_>>,
 ) -> Result<Json<UploadFilesResponse>> {


### PR DESCRIPTION
## 📝 Description

Removes the identity check from identity file upload, otherwise we can't upload an avatar during identity creation.

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
