### PR TITLE
add sat conversion for bill payment link and add timestamps to light …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ dependencies = [
  "rocket_cors",
  "rocket_dyn_templates",
  "rocket_ws",
+ "rust_decimal",
  "serde",
  "serde_json",
  "serde_repr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ lettre = { version = "0.11.10", features = [
   "tokio1-native-tls",
   "file-transport",
 ] }
+rust_decimal = { version = "1.35.0", default-features = false, features = ["std"] }
 nostr-sdk = { version = "0.38.0", features = ["nip59"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 infer = { version = "0.16", default-features = false }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -16,6 +16,9 @@ pub const PAYMENT_DEADLINE_SECONDS: u64 = 86400 * 2; // 2 days
 pub const ACCEPT_DEADLINE_SECONDS: u64 = 86400 * 2; // 2 days
 pub const RECOURSE_DEADLINE_SECONDS: u64 = 86400 * 2; // 2 days
 
+// Currency
+pub const SAT_TO_BTC_RATE: i64 = 100_000_000;
+
 // Validation
 pub const MAX_FILE_SIZE_BYTES: usize = 1_000_000; // ~1 MB
 pub const MAX_FILE_NAME_CHARACTERS: usize = 200;

--- a/src/external/bitcoin.rs
+++ b/src/external/bitcoin.rs
@@ -1,4 +1,4 @@
-use crate::CONFIG;
+use crate::{util, CONFIG};
 use async_trait::async_trait;
 use bitcoin::{secp256k1::Scalar, Network};
 use serde::Deserialize;
@@ -167,7 +167,8 @@ impl BitcoinClientApi for BitcoinClient {
     }
 
     fn generate_link_to_pay(&self, address: &str, sum: u64, message: &str) -> String {
-        let link = format!("bitcoin:{}?amount={}&message={}", address, sum, message);
+        let btc_sum = util::currency::sat_to_btc(sum);
+        let link = format!("bitcoin:{}?amount={}&message={}", address, btc_sum, message);
         link
     }
 

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -3221,6 +3221,8 @@ pub struct LightBitcreditBillToReturn {
     pub sum: String,
     pub currency: String,
     pub issue_date: String,
+    pub time_of_drawing: u64,
+    pub time_of_maturity: u64,
 }
 
 impl From<BitcreditBillToReturn> for LightBitcreditBillToReturn {
@@ -3235,6 +3237,9 @@ impl From<BitcreditBillToReturn> for LightBitcreditBillToReturn {
             sum: value.sum,
             currency: value.currency,
             issue_date: value.issue_date,
+            time_of_drawing: value.time_of_drawing,
+            time_of_maturity: util::date::date_string_to_i64_timestamp(&value.maturity_date, None)
+                .unwrap_or(0) as u64,
         }
     }
 }

--- a/src/service/bill_service.rs
+++ b/src/service/bill_service.rs
@@ -1076,6 +1076,8 @@ impl BillService {
         Ok(BitcreditBillToReturn {
             id: bill.id,
             time_of_drawing,
+            time_of_maturity: util::date::date_string_to_i64_timestamp(&bill.maturity_date, None)
+                .unwrap_or(0) as u64,
             country_of_issuing: bill.country_of_issuing,
             city_of_issuing: bill.city_of_issuing,
             drawee: bill.drawee,
@@ -3248,6 +3250,7 @@ impl From<BitcreditBillToReturn> for LightBitcreditBillToReturn {
 pub struct BitcreditBillToReturn {
     pub id: String,
     pub time_of_drawing: u64,
+    pub time_of_maturity: u64,
     pub country_of_issuing: String,
     pub city_of_issuing: String,
     /// The party obliged to pay a Bill

--- a/src/util/currency.rs
+++ b/src/util/currency.rs
@@ -1,4 +1,8 @@
-use crate::service::{Error, Result};
+use crate::{
+    constants::SAT_TO_BTC_RATE,
+    service::{Error, Result},
+};
+use rust_decimal::Decimal;
 
 pub fn parse_sum(sum: &str) -> Result<u64> {
     match sum.parse::<u64>() {
@@ -9,4 +13,23 @@ pub fn parse_sum(sum: &str) -> Result<u64> {
 
 pub fn sum_to_string(sum: u64) -> String {
     sum.to_string()
+}
+
+pub fn sat_to_btc(val: u64) -> String {
+    let conversion_factor = Decimal::new(1, 0) / Decimal::new(SAT_TO_BTC_RATE, 0);
+    let sat_dec = Decimal::from(val);
+    let btc_dec = sat_dec * conversion_factor;
+    btc_dec.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sat_to_btc_test() {
+        assert_eq!(sat_to_btc(1000), String::from("0.00001000"));
+        assert_eq!(sat_to_btc(10000), String::from("0.00010000"));
+        assert_eq!(sat_to_btc(1), String::from("0.00000001"));
+    }
 }

--- a/src/web/handlers/quotes.rs
+++ b/src/web/handlers/quotes.rs
@@ -24,7 +24,7 @@ pub async fn return_quote(
     let bill_id_hex = hex::encode(bill_id_u8);
     let copy_id_hex = bill_id_hex.clone();
 
-    let local_node_id = get_current_identity_node_id(&state).await;
+    let local_node_id = get_current_identity_node_id(state).await;
     if !quote.bill_id.is_empty() && quote.quote_id.is_empty() {
         // Usage of thread::spawn is necessary here, because we spawn a new tokio runtime in the
         // thread, but this logic will be replaced soon


### PR DESCRIPTION
…bill

## 📝 Description

* Add sat to btc conversion for the link to buy to be correct (uses btc as amount)
* Adds time of maturity and time of drawing for light bills list

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made
See above
---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. Link to buy should now be btc instead of sats as amount
2. Add timestamps to light bills for sorting

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?
