### PR TITLE
Failed message retry

### DIFF
--- a/crates/bcr-ebill-api/src/persistence/mod.rs
+++ b/crates/bcr-ebill-api/src/persistence/mod.rs
@@ -6,9 +6,11 @@ use bcr_ebill_persistence::{
     SurrealIdentityStore, SurrealNostrEventOffsetStore, SurrealNotificationStore,
     bill::{BillChainStoreApi, BillStoreApi},
     company::{CompanyChainStoreApi, CompanyStoreApi},
+    db::nostr_send_queue::SurrealNostrEventQueueStore,
     file_upload::FileUploadStoreApi,
     get_surreal_db,
     identity::{IdentityChainStoreApi, IdentityStoreApi},
+    nostr::NostrQueuedMessageStoreApi,
 };
 use log::error;
 use std::sync::Arc;
@@ -39,6 +41,7 @@ pub struct DbContext {
     pub nostr_event_offset_store: Arc<dyn NostrEventOffsetStoreApi>,
     pub notification_store: Arc<dyn NotificationStoreApi>,
     pub backup_store: Arc<dyn BackupStoreApi>,
+    pub queued_message_store: Arc<dyn NostrQueuedMessageStoreApi>,
 }
 
 /// Creates a new instance of the DbContext with the given SurrealDB configuration.
@@ -77,6 +80,7 @@ pub async fn get_db_context(conf: &Config) -> bcr_ebill_persistence::Result<DbCo
     let nostr_event_offset_store = Arc::new(SurrealNostrEventOffsetStore::new(db.clone()));
     let notification_store = Arc::new(SurrealNotificationStore::new(db.clone()));
     let backup_store = Arc::new(SurrealBackupStore::new(db.clone()));
+    let queued_message_store = Arc::new(SurrealNostrEventQueueStore::new(db.clone()));
 
     Ok(DbContext {
         contact_store,
@@ -90,5 +94,6 @@ pub async fn get_db_context(conf: &Config) -> bcr_ebill_persistence::Result<DbCo
         nostr_event_offset_store,
         notification_store,
         backup_store,
+        queued_message_store,
     })
 }

--- a/crates/bcr-ebill-api/src/service/notification_service/default_service.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/default_service.rs
@@ -408,7 +408,6 @@ impl NotificationServiceApi for DefaultNotificationService {
             .await
             .map(|r| r.first().cloned())
         {
-            println!("got next retry message {q}", q = queued_message.id);
             if let Ok(message) = serde_json::from_value::<EventEnvelope>(queued_message.payload) {
                 if let Err(e) = self
                     .send_retry_message(&message.node_id, message.clone())
@@ -416,14 +415,12 @@ impl NotificationServiceApi for DefaultNotificationService {
                 {
                     error!("Failed to send retry message: {}", e);
                     failed_ids.push(queued_message.id.clone());
-                } else {
-                    if let Err(e) = self
-                        .queued_message_store
-                        .succeed_retry(&queued_message.id)
-                        .await
-                    {
-                        error!("Failed to mark retry message as sent: {}", e);
-                    }
+                } else if let Err(e) = self
+                    .queued_message_store
+                    .succeed_retry(&queued_message.id)
+                    .await
+                {
+                    error!("Failed to mark retry message as sent: {}", e);
                 }
             }
         }

--- a/crates/bcr-ebill-api/src/service/notification_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/mod.rs
@@ -50,14 +50,14 @@ pub async fn create_notification_service(
     client: NostrClient,
     notification_store: Arc<dyn NotificationStoreApi>,
     contact_service: Arc<dyn ContactServiceApi>,
-    message_queue_store: Arc<dyn NostrQueuedMessageStoreApi>,
+    queued_message_store: Arc<dyn NostrQueuedMessageStoreApi>,
 ) -> Result<Arc<dyn NotificationServiceApi>> {
     #[allow(clippy::arc_with_non_send_sync)]
     Ok(Arc::new(DefaultNotificationService::new(
         Box::new(client),
         notification_store,
         contact_service,
-        message_queue_store,
+        queued_message_store,
     )))
 }
 

--- a/crates/bcr-ebill-api/src/service/notification_service/mod.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/mod.rs
@@ -5,6 +5,7 @@ use crate::persistence::identity::IdentityStoreApi;
 use crate::persistence::nostr::NostrEventOffsetStoreApi;
 use crate::persistence::notification::NotificationStoreApi;
 use bcr_ebill_persistence::bill::{BillChainStoreApi, BillStoreApi};
+use bcr_ebill_persistence::nostr::NostrQueuedMessageStoreApi;
 use bcr_ebill_transport::handler::{
     BillChainEventHandler, LoggingEventHandler, NotificationHandlerApi,
 };
@@ -49,12 +50,14 @@ pub async fn create_notification_service(
     client: NostrClient,
     notification_store: Arc<dyn NotificationStoreApi>,
     contact_service: Arc<dyn ContactServiceApi>,
+    message_queue_store: Arc<dyn NostrQueuedMessageStoreApi>,
 ) -> Result<Arc<dyn NotificationServiceApi>> {
     #[allow(clippy::arc_with_non_send_sync)]
     Ok(Arc::new(DefaultNotificationService::new(
         Box::new(client),
         notification_store,
         contact_service,
+        message_queue_store,
     )))
 }
 

--- a/crates/bcr-ebill-api/src/service/notification_service/test_utils.rs
+++ b/crates/bcr-ebill-api/src/service/notification_service/test_utils.rs
@@ -5,8 +5,8 @@ use crate::{
         MockBackupStoreApiMock, MockBillChainStoreApiMock, MockBillStoreApiMock,
         MockCompanyChainStoreApiMock, MockCompanyStoreApiMock, MockContactStoreApiMock,
         MockFileUploadStoreApiMock, MockIdentityChainStoreApiMock, MockIdentityStoreApiMock,
-        MockNostrEventOffsetStoreApiMock, MockNotificationStoreApiMock, empty_bitcredit_bill,
-        identity_public_data_only_node_id,
+        MockNostrEventOffsetStoreApiMock, MockNostrQueuedMessageStore,
+        MockNotificationStoreApiMock, empty_bitcredit_bill, identity_public_data_only_node_id,
     },
     util::BcrKeys,
 };
@@ -151,5 +151,6 @@ pub fn get_mock_db_context() -> DbContext {
         nostr_event_offset_store: Arc::new(MockNostrEventOffsetStoreApiMock::new()),
         notification_store: Arc::new(MockNotificationStoreApiMock::new()),
         backup_store: Arc::new(MockBackupStoreApiMock::new()),
+        queued_message_store: Arc::new(MockNostrQueuedMessageStore::new()),
     }
 }

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -24,6 +24,7 @@ pub mod tests {
         company::{CompanyChainStoreApi, CompanyStoreApi},
         file_upload::FileUploadStoreApi,
         identity::{IdentityChainStoreApi, IdentityStoreApi},
+        nostr::{NostrQueuedMessage, NostrQueuedMessageStoreApi},
         notification::NotificationFilter,
     };
     use bcr_ebill_transport::{BillChainEvent, NotificationServiceApi};
@@ -152,6 +153,18 @@ pub mod tests {
             async fn current_offset(&self) -> Result<u64>;
             async fn is_processed(&self, event_id: &str) -> Result<bool>;
             async fn add_event(&self, data: NostrEventOffset) -> Result<()>;
+        }
+    }
+
+    mockall::mock! {
+        pub NostrQueuedMessageStore {}
+
+        #[async_trait]
+        impl NostrQueuedMessageStoreApi for NostrQueuedMessageStore {
+            async fn add_message(&self, message: NostrQueuedMessage, max_retries: i32) -> Result<()>;
+            async fn get_retry_messages(&self, limit: u64) -> Result<Vec<NostrQueuedMessage>>;
+            async fn fail_retry(&self, id: &str) -> Result<()>;
+            async fn succeed_retry(&self, id: &str) -> Result<()>;
         }
     }
 

--- a/crates/bcr-ebill-api/src/tests/mod.rs
+++ b/crates/bcr-ebill-api/src/tests/mod.rs
@@ -291,6 +291,7 @@ pub mod tests {
                 block_height: i32,
                 action: ActionType,
             ) -> bcr_ebill_transport::Result<()>;
+            async fn send_retry_messages(&self) -> bcr_ebill_transport::Result<()>;
         }
     }
 

--- a/crates/bcr-ebill-transport/src/notification_service.rs
+++ b/crates/bcr-ebill-transport/src/notification_service.rs
@@ -150,4 +150,7 @@ pub trait NotificationServiceApi: ServiceTraitBounds {
         block_height: i32,
         action: ActionType,
     ) -> Result<()>;
+
+    /// Retry sending a queued message to the given node id
+    async fn send_retry_messages(&self) -> Result<()>;
 }

--- a/crates/bcr-ebill-wasm/src/context.rs
+++ b/crates/bcr-ebill-wasm/src/context.rs
@@ -52,6 +52,7 @@ impl Context {
             nostr_client.clone(),
             db.notification_store.clone(),
             contact_service.clone(),
+            db.queued_message_store.clone(),
         )
         .await?;
 

--- a/crates/bcr-ebill-wasm/src/job.rs
+++ b/crates/bcr-ebill-wasm/src/job.rs
@@ -8,7 +8,8 @@ pub fn run_jobs() {
         futures::join!(
             run_check_bill_payment_job(),
             run_check_bill_offer_to_sell_payment_job(),
-            run_check_bill_recourse_payment_job()
+            run_check_bill_recourse_payment_job(),
+            run_process_nostr_message_queue_job(),
         );
         run_check_bill_timeouts().await;
     });
@@ -58,4 +59,12 @@ async fn run_check_bill_timeouts() {
     }
 
     info!("Finished running Check Bill Timeouts Job");
+}
+
+async fn run_process_nostr_message_queue_job() {
+    info!("Running process Nostr message queue Job");
+    if let Err(e) = get_ctx().notification_service.send_retry_messages().await {
+        error!("Error while running process Nostr message queue Job: {e}");
+    }
+    info!("Finished running process Nostr message queue Job");
 }

--- a/crates/bcr-ebill-web/src/service_context.rs
+++ b/crates/bcr-ebill-web/src/service_context.rs
@@ -96,6 +96,7 @@ pub async fn create_service_context(
         nostr_client.clone(),
         db.notification_store.clone(),
         contact_service.clone(),
+        db.queued_message_store.clone(),
     )
     .await?;
 


### PR DESCRIPTION
### **User description**
## 📝 Description

Adds retry job for sending chain events. Messages will be retried up to 10 times triggered by the current scheduler. If we want to get a bit more efficient we can add an exponential back-off later.

Relates to #297

---

## ✅ Checklist

Please ensure the following tasks are completed before requesting a review:

- [x] My code adheres to the coding guidelines of this project.
- [x] I have run `cargo fmt`.
- [x] I have run `cargo clippy`.
- [x] I have added or updated tests (if applicable).
- [x] All CI/CD steps were successful.
- [x] I have updated the documentation (if applicable).
- [x] I have checked that there are no console errors or warnings.
- [x] I have verified that the application builds without errors.
- [x] I've described the changes made to the API. (modification, addition, deletion).

---

## 🚀 Changes Made

- **New Features:**
  - Automatically retry sending Nostr chain events if delivery fails

---

## 💡 How to Test

Please provide clear instructions on how reviewers can test your changes:

1. cargo test

---

## 🤝 Related Issues

List any related issues, pull requests, or discussions:

- #424

---

## 📋 Review Guidelines

Please focus on the following while reviewing:

- [ ] Does the code follow the repository's contribution guidelines?
- [ ] Are there any potential bugs or performance issues?
- [ ] Are there any typos or grammatical errors in the code or comments?


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced a retry mechanism for failed Nostr message deliveries.
  - Added a queue to store failed messages with retry logic.
  - Implemented a job to process and retry queued messages.

- Enhanced `DbContext` to include `NostrQueuedMessageStoreApi`.

- Updated notification service to handle retries and integrate with the message queue.

- Added comprehensive tests for retry logic, including edge cases and error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>mod.rs</strong><dd><code>Added NostrQueuedMessageStoreApi to DbContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-d89d28d4200c90484ca080e04499928227cf65ee7857931621617d034845ea9c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>default_service.rs</strong><dd><code>Implemented retry logic for failed Nostr messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-a7465b19a0de744da31082e747b854d7196296da443f668f516f58e7936423bf">+546/-18</a></td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Updated notification service creation to include retry queue</code></dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-5e4582d88d28c90be7fe309bfd3facef93108f563c5cb55fa44350316e27a5e6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>notification_service.rs</strong><dd><code>Extended NotificationServiceApi with retry functionality</code>&nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-3d0a1f93baac17cad711250480de3ed125953511c77cb770e2b5ba81274e18f1">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>context.rs</strong><dd><code>Integrated retry queue into WASM context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-4aab47a7683b01dc13d3bd22573728e6f581df241ee8a3e6eb19d12521bd635f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>job.rs</strong><dd><code>Added job to process Nostr message retry queue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-739e234452ac68eb6d4ee619fed093bc9fffcff992ef48215f9ee60fd05de37a">+10/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>service_context.rs</strong><dd><code>Integrated retry queue into web service context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-2bc9ef2eca1470d42d8c155ab475fda277a11bfefee32a9a6f0a48f447169b0e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_utils.rs</strong><dd><code>Added mock for NostrQueuedMessageStore</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-cf644a00547031931e4687af48d33baf744a1a001e5b215caa46753fd43dff39">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Added tests for retry logic and NostrQueuedMessageStore</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/BitcreditProtocol/E-Bill/pull/448/files#diff-49db059de3206a221445a6f9d2745edf8e81decc03c3ac08e49ceb1d727b2a02">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>